### PR TITLE
More efficient .get(), less dangerous .delete()

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,9 @@
 # Model class for site settings
 class Setting < ApplicationRecord
+  # Class methods
+
+  # Return the value of the specified setting
   def self.get( name )
-    find_by( name: name )&.value
+    where( name: name).pluck( :value )
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -4,6 +4,6 @@ class Setting < ApplicationRecord
 
   # Return the value of the specified setting
   def self.get( name )
-    where( name: name).pluck( :value )
+    where( name: name).pluck( :value ).first
   end
 end

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -4,7 +4,7 @@
   <% @settings.each do |s| %>
   <p>
     <label for="shinycms_setting_<%= s.id %>"><%= s.name %></label>
-    <%= text_field :settings, "shinycms_setting_#{s.id}", value: s.value %>
+    <%= text_field :settings, "shinycms_setting_#{s.id}", value: s.value, method: :delete %>
     <%= link_to 'Delete', admin_setting_delete_path( s ) %>
   </p>
   <% end %>


### PR DESCRIPTION
* Create less overhead in the .get method, by using .pluck() instead of .find_by().value
* Prevent link preloaders from causing setting-removal chaos, by using DELETE instead of GET for the delete link.