### PR TITLE
Remove unneeded rescue block

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -15,9 +15,6 @@ class Admin::SettingsController < AdminController
       flash[ :alert ] = I18n.t 'setting_create_failed'
     end
     redirect_to admin_settings_path
-  rescue ActiveRecord::NotNullViolation
-    flash[ :alert ] = I18n.t 'setting_create_failed'
-    redirect_to admin_settings_path
   end
 
   # Main form submitted; update any changed settings and report back


### PR DESCRIPTION
The tests seem to show that the validation fail check is enough to keep us safe here; no need to rescue.