### PR TITLE
Fix Faker uniqueness

### DIFF
--- a/spec/factories/capabilities.rb
+++ b/spec/factories/capabilities.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :capability do
-    name { Faker::Science.unique.scientist }
+    name { Faker::Lorem.unique.word }
 
     association :category, factory: :capability_category
   end

--- a/spec/factories/capability_categories.rb
+++ b/spec/factories/capability_categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :capability_category do
-    name { Faker::Science.unique.element }
+    name { Faker::Lorem.unique.word }
   end
 end

--- a/spec/factories/feature_flags.rb
+++ b/spec/factories/feature_flags.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :feature_flag do
-    name  { Faker::Science.unique.scientist }
+    name { Faker::Lorem.unique.word }
   end
 end

--- a/spec/factories/page_elements.rb
+++ b/spec/factories/page_elements.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page_element do
-    name { Faker::Science.unique.element }
+    name { Faker::Lorem.unique.word.downcase }
   end
 
   factory :short_text_page_element, parent: :page_element do

--- a/spec/factories/page_sections.rb
+++ b/spec/factories/page_sections.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page_section, aliases: [ :top_level_section ] do
-    name   { Faker::Science.unique.element }
+    name   { Faker::Lorem.unique.sentence }
     title  { name.dup.titlecase }
     slug   { name.dup.downcase.gsub( /\s+/, '-' ) }
     hidden { false }

--- a/spec/factories/page_template_elements.rb
+++ b/spec/factories/page_template_elements.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page_template_element do
-    name { Faker::Science.unique.element }
+    name { Faker::Lorem.unique.word }
     content_type { I18n.t( 'admin.elements.short_text' ) }
   end
 end

--- a/spec/factories/page_templates.rb
+++ b/spec/factories/page_templates.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page_template do
-    name     { Faker::Science.unique.scientist }
+    name { Faker::Lorem.unique.word }
     filename { 'an_example' }
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page, aliases: [ :top_level_page ] do
-    name   { Faker::Loren.unique.sentence }
+    name   { Faker::Lorem.unique.sentence }
     title  { name.dup.titlecase }
     slug   { name.dup.downcase.gsub( /\s+/, '-' ) }
     hidden { false }

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page, aliases: [ :top_level_page ] do
-    name   { Faker::Science.unique.element }
+    name   { Faker::Loren.unique.sentence }
     title  { name.dup.titlecase }
     slug   { name.dup.downcase.gsub( /\s+/, '-' ) }
     hidden { false }

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :setting do
-    name  { Faker::Science.unique.scientist }
-    value { Faker::Science.element }
+    name  { Faker::Lorem.unique.word }
+    value { Faker::Lorem.unique.word }
   end
 end

--- a/spec/factories/shared_content_elements.rb
+++ b/spec/factories/shared_content_elements.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :shared_content_element do
-    name    { Faker::Science.unique.element }
-    content { Faker::Science.scientist      }
+    name    { Faker::Lorem.unique.word.downcase }
+    content { Faker::Lorem.unique.sentence }
     content_type { I18n.t( 'admin.elements.short_text' ) }
   end
 end

--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -2,6 +2,5 @@
 RSpec.configure do |config|
   config.before :each do
     Faker::UniqueGenerator.clear
-    Faker::Science.unique.exclude :element, nil, [ 'Tin' ]
   end
 end


### PR DESCRIPTION
I kept getting test failures from element names like 'tin' and similar colliding with parts of words on my pages (in expect(...).not_to include(...) tests), which was tedious. So, Lorem; it's not as much fun as Science, but it's less likely to contain parts of real words. Meh.