### PR TITLE
More consistent page title and alert message i18n keys

### DIFF
--- a/app/controllers/admin/pages/sections_controller.rb
+++ b/app/controllers/admin/pages/sections_controller.rb
@@ -18,10 +18,10 @@ class Admin::Pages::SectionsController < AdminController
     authorise @section
 
     if @section.save
-      flash[ :notice ] = t( '.section_created' )
+      flash[ :notice ] = t( '.success' )
       redirect_to action: :edit, id: @section.id
     else
-      flash.now[ :alert ] = t( '.section_create_failed' )
+      flash.now[ :alert ] = t( '.failure' )
       render action: :new
     end
   end
@@ -36,10 +36,10 @@ class Admin::Pages::SectionsController < AdminController
     authorise @section
 
     if @section.update( section_params )
-      flash[ :notice ] = t( '.section_updated' )
+      flash[ :notice ] = t( '.success' )
       redirect_to action: :edit, id: @section.id
     else
-      flash.now[ :alert ] = t( '.section_update_failed' )
+      flash.now[ :alert ] = t( '.failure' )
       render :edit
     end
   end
@@ -48,10 +48,10 @@ class Admin::Pages::SectionsController < AdminController
     section = PageSection.find( params[:id] )
     authorise section
 
-    flash[ :notice ] = t( '.section_deleted' ) if section.destroy
+    flash[ :notice ] = t( '.success' ) if section.destroy
     redirect_to admin_pages_path
   rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordNotFound
-    handle_delete_exceptions t( '.section_delete_failed' ), admin_pages_path
+    handle_delete_exceptions t( '.failure' ), admin_pages_path
   end
 
   private

--- a/app/controllers/admin/pages/templates_controller.rb
+++ b/app/controllers/admin/pages/templates_controller.rb
@@ -21,10 +21,10 @@ class Admin::Pages::TemplatesController < AdminController
     authorise @template
 
     if @template.save
-      flash[ :notice ] = t( '.template_created' )
+      flash[ :notice ] = t( '.success' )
       redirect_to action: :edit, id: @template.id
     else
-      flash.now[ :alert ] = t( '.template_create_failed' )
+      flash.now[ :alert ] = t( '.failure' )
       render action: :new
     end
   end
@@ -39,10 +39,10 @@ class Admin::Pages::TemplatesController < AdminController
     authorise @template
 
     if @template.update( template_params )
-      flash[ :notice ] = t( '.template_updated' )
+      flash[ :notice ] = t( '.success' )
       redirect_to action: :edit, id: @template.id
     else
-      flash.now[ :alert ] = t( '.template_update_failed' )
+      flash.now[ :alert ] = t( '.failure' )
       render :edit
     end
   end
@@ -51,10 +51,10 @@ class Admin::Pages::TemplatesController < AdminController
     template = PageTemplate.find( params[:id] )
     authorise template
 
-    flash[ :notice ] = t( '.template_deleted' ) if template.destroy
+    flash[ :notice ] = t( '.success' ) if template.destroy
     redirect_to admin_pages_templates_path
   rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordNotFound
-    handle_delete_exceptions t( '.template_delete_failed' ),
+    handle_delete_exceptions t( '.failure' ),
                              admin_pages_templates_path
   end
 

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -24,10 +24,10 @@ class Admin::PagesController < AdminController
     authorise @page
 
     if @page.save
-      flash[ :notice ] = t( '.page_created' )
+      flash[ :notice ] = t( '.success' )
       redirect_to action: :edit, id: @page.id
     else
-      flash.now[ :alert ] = t( '.page_create_failed' )
+      flash.now[ :alert ] = t( '.failure' )
       render action: :new
     end
   end
@@ -42,10 +42,10 @@ class Admin::PagesController < AdminController
     authorise @page
 
     if @page.update( page_params )
-      flash[ :notice ] = t( '.page_updated' )
+      flash[ :notice ] = t( '.success' )
       redirect_to action: :edit, id: @page.id
     else
-      flash.now[ :alert ] = t( '.page_update_failed' )
+      flash.now[ :alert ] = t( '.failure' )
       render action: :edit
     end
   end
@@ -54,10 +54,10 @@ class Admin::PagesController < AdminController
     page = Page.find( params[:id] )
     authorise page
 
-    flash[ :notice ] = t( '.page_deleted' ) if page.destroy
+    flash[ :notice ] = t( '.success' ) if page.destroy
     redirect_to admin_pages_path
   rescue ActiveRecord::RecordNotFound, ActiveRecord::NotNullViolation
-    handle_delete_exceptions t( '.page_delete_failed' ), admin_pages_path
+    handle_delete_exceptions t( '.failure' ), admin_pages_path
   end
 
   private

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -10,9 +10,9 @@ class Admin::SettingsController < AdminController
     setting = Setting.new( setting_params )
 
     if setting.save
-      flash[ :notice ] = t( '.setting_created' )
+      flash[ :notice ] = t( '.success' )
     else
-      flash[ :alert ] = t( '.setting_create_failed' )
+      flash[ :alert ] = t( '.failure' )
     end
     redirect_to admin_settings_path
   end
@@ -22,9 +22,9 @@ class Admin::SettingsController < AdminController
     updated_settings = false
     updated_settings = update_settings( updated_settings )
     if updated_settings
-      flash[ :notice ] = t( '.settings_updated' )
+      flash[ :notice ] = t( '.success' )
     else
-      flash[ :alert ] = t( '.settings_update_failed' )
+      flash[ :alert ] = t( '.failure' )
     end
     redirect_to admin_settings_path
   end
@@ -32,10 +32,10 @@ class Admin::SettingsController < AdminController
   def delete
     setting = Setting.find( params[:id] )
 
-    flash[ :notice ] = t( '.setting_deleted' ) if setting.destroy
+    flash[ :notice ] = t( '.success' ) if setting.destroy
     redirect_to admin_settings_path
   rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordNotFound
-    handle_delete_exceptions t( '.setting_delete_failed' ), admin_settings_path
+    handle_delete_exceptions t( '.failure' ), admin_settings_path
   end
 
   private

--- a/app/controllers/admin/shared_content_controller.rb
+++ b/app/controllers/admin/shared_content_controller.rb
@@ -18,9 +18,9 @@ class Admin::SharedContentController < AdminController
     authorise @new_element
 
     if @new_element.save
-      flash[ :notice ] = t( '.shared_content_created' )
+      flash[ :notice ] = t( '.success' )
     else
-      flash[ :alert ] = t( '.shared_content_create_failed' )
+      flash[ :alert ] = t( '.failure' )
     end
     redirect_to admin_shared_content_path
   end
@@ -34,12 +34,12 @@ class Admin::SharedContentController < AdminController
 
     @shared_content.elements_attributes = shared_content_params
 
-    flash[ :notice ] = t( '.shared_content_updated' ) if @shared_content.valid?
+    flash[ :notice ] = t( '.success' ) if @shared_content.valid?
     redirect_to admin_shared_content_path
   rescue ActiveRecord::RecordNotUnique
     skip_authorization
     redirect_to admin_shared_content_path,
-                alert: t( '.shared_content_update_failed' )
+                alert: t( '.failure' )
   end
 
   def delete
@@ -47,10 +47,10 @@ class Admin::SharedContentController < AdminController
 
     authorise element
 
-    flash[ :notice ] = t( '.shared_content_deleted' ) if element.destroy
+    flash[ :notice ] = t( '.success' ) if element.destroy
     redirect_to admin_shared_content_path
   rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordNotFound
-    handle_delete_exceptions t( '.shared_content_delete_failed' ),
+    handle_delete_exceptions t( '.failure' ),
                              admin_shared_content_path
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,10 +18,10 @@ class Admin::UsersController < AdminController
     authorise @user
 
     if @user.save
-      flash[ :notice ] = t( '.user_created' )
+      flash[ :notice ] = t( '.success' )
       redirect_to action: :edit, id: @user.id
     else
-      flash.now[ :alert ] = t( '.user_create_failed' )
+      flash.now[ :alert ] = t( '.failure' )
       render action: :new
     end
   end
@@ -36,10 +36,10 @@ class Admin::UsersController < AdminController
     authorise @user
 
     if @user.update_without_password( user_params )
-      flash[ :notice ] = t( '.user_updated' )
+      flash[ :notice ] = t( '.success' )
       redirect_to action: :edit, id: @user.id
     else
-      flash.now[ :alert ] = t( '.user_update_failed' )
+      flash.now[ :alert ] = t( '.failure' )
       render action: :edit
     end
   end
@@ -48,10 +48,10 @@ class Admin::UsersController < AdminController
     user = User.find( params[:id] )
     authorise user
 
-    flash[ :notice ] = t( '.user_deleted' ) if user.destroy
+    flash[ :notice ] = t( '.success' ) if user.destroy
     redirect_to admin_users_path
   rescue ActiveRecord::RecordNotFound, ActiveRecord::NotNullViolation
-    handle_delete_exceptions t( '.user_delete_failed' ), admin_users_path
+    handle_delete_exceptions t( '.failure' ), admin_users_path
   end
 
   private

--- a/app/views/admin/pages/edit.html.erb
+++ b/app/views/admin/pages/edit.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.edit_page' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_for @page, url: admin_page_path( @page ), method: :post do |f| %>
   <p>

--- a/app/views/admin/pages/index.html.erb
+++ b/app/views/admin/pages/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.list_pages' ) %>
+<% @page_title = t( '.title' ) %>
 
 <% if @tl_pages.present? || @tl_sections.present? %>
 <table class="table table-responsive-sm table-striped">

--- a/app/views/admin/pages/new.html.erb
+++ b/app/views/admin/pages/new.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.new_page' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_for :page, url: admin_page_new_path, method: :post do |f| %>
   <p>

--- a/app/views/admin/pages/sections/edit.html.erb
+++ b/app/views/admin/pages/sections/edit.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.edit_section' ) %>
+<% @page_title = t( '.title' ) %>
 
 
 <%= form_for @section, url: admin_pages_section_path( @section ), method: :post do |f| %>

--- a/app/views/admin/pages/sections/new.html.erb
+++ b/app/views/admin/pages/sections/new.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.new_section' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_for :page_section, url: admin_pages_section_new_path, method: :post do |f| %>
   <p>

--- a/app/views/admin/pages/templates/edit.html.erb
+++ b/app/views/admin/pages/templates/edit.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.edit_template' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_for @template, url: admin_pages_template_path( @template ), method: :post do |f| %>
   <p>

--- a/app/views/admin/pages/templates/index.html.erb
+++ b/app/views/admin/pages/templates/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.list_templates' ) %>
+<% @page_title = t( '.title' ) %>
 
 <% if @templates.present? %>
 <table class="table table-responsive-sm table-striped">

--- a/app/views/admin/pages/templates/new.html.erb
+++ b/app/views/admin/pages/templates/new.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.new_template' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_for :page_template, url: admin_pages_template_new_path, method: :post do |f| %>
   <p>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.site_settings' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_with name: 'all_settings', url: admin_settings_path, method: :post do %>
 <table class="table table-responsive-sm table-striped">

--- a/app/views/admin/shared_content/index.html.erb
+++ b/app/views/admin/shared_content/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.shared_content' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_with model: @shared_content, name: 'shared_content', url: admin_shared_content_path, method: :post do |f| %>
 <table class="table table-responsive-sm table-striped">

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.edit_user' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_for @user, url: admin_user_path( @user ), method: :post do |f| %>
   <p>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.list_users' ) %>
+<% @page_title = t( '.title' ) %>
 
 <% if @users.present? %>
 <table class="table table-responsive-sm table-striped">

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = t( '.new_user' ) %>
+<% @page_title = t( '.title' ) %>
 
 <%= form_for :user, url: admin_user_new_path, method: :post do |f| %>
   <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,105 +81,105 @@ en:
 
     pages:
       index:
-        list_pages: List pages
+        title: List pages
       new:
-        new_page: Add new page
+        title: Add new page
       edit:
-        edit_page: Edit page
+        title: Edit page
       create:
-        page_created: New page added
-        page_create_failed: Failed to add new page
+        success: New page added
+        failure: Failed to add new page
       update:
-        page_updated: Page details updated
-        page_update_failed: Failed to update page details
+        success: Page details updated
+        failure: Failed to update page details
       delete:
-        page_deleted: Page deleted
-        page_delete_failed: Failed to delete page
+        success: Page deleted
+        failure: Failed to delete page
 
       sections:
         new:
-          new_section: Add new section
+          title: Add new section
         edit:
-          edit_section: Edit section
+          title: Edit section
         create:
-          section_created: New section added
-          section_create_failed: Failed to add new section
+          success: New section added
+          failure: Failed to add new section
         update:
-          section_updated: Section details updated
-          section_update_failed: Failed to update section details
+          success: Section details updated
+          failure: Failed to update section details
         delete:
-          section_deleted: Section deleted
-          section_delete_failed: Failed to section page
+          success: Section deleted
+          failure: Failed to section page
 
       templates:
         index:
-          list_templates: List templates
+          title: List templates
         new:
-          new_template: Add new template
+          title: Add new template
         edit:
-          edit_template: Edit template
+          title: Edit template
         create:
-          template_created: New template added
-          template_create_failed: Failed to add new template
+          success: New template added
+          failure: Failed to add new template
         update:
-          template_updated: Template details updated
-          template_update_failed: Failed to update template details
+          success: Template details updated
+          failure: Failed to update template details
         delete:
-          template_deleted: Template deleted
-          template_delete_failed: Failed to delete template
+          success: Template deleted
+          failure: Failed to delete template
 
     settings:
       admin_ip_list: Admin IP list
       default_page: Default page
       default_section: Default section
       index:
-        site_settings: Site Settings
+        title: Site Settings
         name_placeholder: Setting name
         value_placeholder: Setting value (can be blank)
         description_placeholder: Description (optional)
       create:
-        setting_created: New setting added
-        setting_create_failed: Failed to add new setting
+        success: New setting added
+        failure: Failed to add new setting
       update:
-        settings_updated: Settings updated
-        # settings_unchanged: Settings unchanged
-        settings_update_failed: Failed to update settings
+        success: Settings updated
+        # unchanged: Settings unchanged
+        failure: Failed to update settings
       delete:
-        setting_deleted: Setting deleted
-        setting_delete_failed: Failed to delete setting
+        success: Setting deleted
+        failure: Failed to delete setting
 
     shared_content:
       index:
-        shared_content: Shared content
+        title: Shared content
         name_placeholder: Name
         content_placeholder: Content (can be blank)
       create:
-        shared_content_created: New shared content added
-        shared_content_create_failed: Failed to add new shared content
+        success: New shared content added
+        failure: Failed to add new shared content
       update:
-        shared_content_updated: Shared content updated
-        # shared_content_unchanged: Shared content unchanged
-        shared_content_update_failed: Failed to update shared content
+        success: Shared content updated
+        # unchanged: Shared content unchanged
+        failure: Failed to update shared content
       delete:
-        shared_content_deleted: Specified shared content deleted
-        shared_content_delete_failed: Failed to delete specified shared content
+        success: Specified shared content deleted
+        failure: Failed to delete specified shared content
 
     users:
       index:
-        list_users: List users
+        title: List users
       new:
-        new_user: Add new user
+        title: Add new user
       edit:
-        edit_user: Edit user
+        title: Edit user
       create:
-        user_created: New user added
-        user_create_failed: Failed to add new user
+        success: New user added
+        failure: Failed to add new user
       update:
-        user_updated: User details updated
-        user_update_failed: Failed to update user details
+        success: User details updated
+        failure: Failed to update user details
       delete:
-        user_deleted: User deleted
-        user_delete_failed: Failed to delete user
+        success: User deleted
+        failure: Failed to delete user
 
   models:
     page_template:

--- a/spec/request/admin/pages/sections_spec.rb
+++ b/spec/request/admin/pages/sections_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       expect( response      ).to redirect_to admin_pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.index.list_pages' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       get admin_pages_section_new_path
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.new.new_section' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.new.title' ).titlecase
     end
   end
 
@@ -34,8 +34,8 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       }
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.new.new_section' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.create.section_create_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.new.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.create.failure' )
     end
 
     it 'fails if top-level section slug collides with a controller namespace' do
@@ -46,8 +46,8 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       }
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.new.new_section' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.create.section_create_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.new.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.create.failure' )
     end
 
     it 'adds a new section when the form is submitted' do
@@ -61,8 +61,8 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       expect( response      ).to redirect_to admin_pages_section_path( PageSection.last )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.edit_section' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.sections.create.section_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.sections.create.success' )
     end
   end
 
@@ -73,7 +73,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       get admin_pages_section_path( section )
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.edit_section' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.title' ).titlecase
     end
   end
 
@@ -86,8 +86,8 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       }
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.edit_section' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.update.section_update_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.update.failure' )
     end
 
     it 'updates the section when the form is submitted' do
@@ -101,8 +101,8 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       expect( response      ).to redirect_to admin_pages_section_path( section )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.edit_section' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.sections.update.section_updated' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.sections.update.success' )
       expect( response.body ).to include 'Updated by test'
     end
   end
@@ -119,8 +119,8 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       expect( response      ).to     redirect_to admin_pages_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.pages.index.list_pages' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.sections.delete.section_deleted' )
+      expect( response.body ).to     have_title I18n.t( 'admin.pages.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.sections.delete.success' )
       expect( response.body ).to     include s1.name
       expect( response.body ).not_to include s2.name
       expect( response.body ).to     include s3.name
@@ -133,8 +133,8 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       expect( response      ).to redirect_to admin_pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.index.list_pages' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.delete.section_delete_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.delete.failure' )
     end
   end
 end

--- a/spec/request/admin/pages/templates_spec.rb
+++ b/spec/request/admin/pages/templates_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       get admin_pages_templates_path
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.index.list_templates' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.index.title' ).titlecase
       expect( response.body ).to include template.name
     end
   end
@@ -23,7 +23,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       get admin_pages_template_new_path
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.new.new_template' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.new.title' ).titlecase
     end
   end
 
@@ -34,8 +34,8 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       }
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.new.new_template' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.templates.create.template_create_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.new.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.templates.create.failure' )
     end
 
     it 'adds a new template when the form is submitted' do
@@ -47,8 +47,8 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       expect( response      ).to have_http_status :found
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.edit_template' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.templates.create.template_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.templates.create.success' )
     end
 
     it 'adds the right number of elements to the new template' do
@@ -60,8 +60,8 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       expect( response      ).to have_http_status :found
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.edit_template' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.templates.create.template_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.templates.create.success' )
       expect( PageTemplateElement.count ).to eq 4
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       get admin_pages_template_path( template )
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.edit_template' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.title' ).titlecase
     end
   end
 
@@ -86,8 +86,8 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       }
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.edit_template' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.templates.update.template_update_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.templates.update.failure' )
     end
 
     it 'updates the template when the form is submitted' do
@@ -104,8 +104,8 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       expect( response      ).to have_http_status :found
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.edit_template' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.templates.update.template_updated' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.templates.update.success' )
       expect( response.body ).to include 'Updated by test'
     end
   end
@@ -122,8 +122,8 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       expect( response      ).to     redirect_to admin_pages_templates_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.pages.templates.index.list_templates' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.templates.delete.template_deleted' )
+      expect( response.body ).to     have_title I18n.t( 'admin.pages.templates.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.templates.delete.success' )
       expect( response.body ).to     include t1.name
       expect( response.body ).not_to include t2.name
     end
@@ -135,8 +135,8 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       expect( response      ).to redirect_to admin_pages_templates_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.index.list_templates' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.templates.delete.template_delete_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.templates.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.templates.delete.failure' )
     end
   end
 end

--- a/spec/request/admin/pages_spec.rb
+++ b/spec/request/admin/pages_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Admin: Pages', type: :request do
       get admin_pages_path
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.index.list_pages' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
 
       expect( response.body ).to include page.name
       expect( response.body ).to include subpage.name
@@ -35,7 +35,7 @@ RSpec.describe 'Admin: Pages', type: :request do
       get admin_page_new_path
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.new.new_page' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.new.title' ).titlecase
     end
   end
 
@@ -46,8 +46,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       }
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.new.new_page' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.create.page_create_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.new.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.create.failure' )
     end
 
     it 'fails when the page slug collides with a controller namespace' do
@@ -61,8 +61,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       }
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.new.new_page' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.create.page_create_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.new.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.create.failure' )
     end
 
     it 'adds a new page when the form is submitted' do
@@ -77,8 +77,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       expect( response      ).to redirect_to admin_page_path( Page.last )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.edit_page' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.create.page_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.create.success' )
     end
 
     it 'adds a new page with elements from template' do
@@ -95,8 +95,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       expect( response      ).to redirect_to admin_page_path( Page.last )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.edit_page' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.create.page_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.create.success' )
       expect( response.body ).to include template.elements.first.name
       expect( response.body ).to include template.elements.last.name
     end
@@ -109,7 +109,7 @@ RSpec.describe 'Admin: Pages', type: :request do
       get admin_page_path( page )
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.edit_page' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
     end
   end
 
@@ -122,8 +122,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       }
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.edit_page' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.update.page_update_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.update.failure' )
     end
 
     it 'updates the page when the form is submitted' do
@@ -137,8 +137,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       expect( response      ).to redirect_to admin_page_path( page )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.edit_page' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.update.page_updated' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.pages.update.success' )
       expect( response.body ).to include 'Updated by test'
     end
 
@@ -155,8 +155,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       expect( response      ).to     redirect_to admin_page_path( page )
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.pages.edit.edit_page' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.update.page_updated' )
+      expect( response.body ).to     have_title I18n.t( 'admin.pages.edit.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.update.success' )
       expect( response.body ).to     include 'updated-by-test'
       expect( response.body ).not_to include old_slug
     end
@@ -167,7 +167,7 @@ RSpec.describe 'Admin: Pages', type: :request do
       get admin_page_path( page )
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.edit_page' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
 
       expect( response.body ).to match %r{<input [^>]*value="SHORT!"[^>]*>}
       expect( response.body ).to match %r{<textarea [^>]+>\nLONG!</textarea>}
@@ -191,8 +191,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       expect( response      ).to     redirect_to admin_pages_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.pages.index.list_pages' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.delete.page_deleted' )
+      expect( response.body ).to     have_title I18n.t( 'admin.pages.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.delete.success' )
       expect( response.body ).to     include p1.name
       expect( response.body ).not_to include p2.name
       expect( response.body ).to     include p3.name
@@ -205,8 +205,8 @@ RSpec.describe 'Admin: Pages', type: :request do
       expect( response      ).to redirect_to admin_pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.index.list_pages' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.delete.page_delete_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.delete.failure' )
     end
   end
 end

--- a/spec/request/admin/settings_spec.rb
+++ b/spec/request/admin/settings_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       get admin_settings_path
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
     end
   end
 
@@ -26,8 +26,8 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       expect( response      ).to redirect_to admin_settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.settings.create.setting_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.settings.create.success' )
       expect( response.body ).to include 'New Setting Is New'
     end
 
@@ -41,8 +41,8 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       expect( response      ).to redirect_to admin_settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.settings.create.setting_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.settings.create.success' )
       expect( response.body ).to include 'New Setting Is Empty'
     end
 
@@ -56,8 +56,8 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       expect( response      ).to redirect_to admin_settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.settings.create.setting_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.settings.create.success' )
       expect( response.body ).to include 'New Setting Is Null'
     end
 
@@ -70,8 +70,8 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       expect( response      ).to redirect_to admin_settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.settings.create.setting_create_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.settings.create.failure' )
     end
   end
 
@@ -87,8 +87,8 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       expect( response      ).to     redirect_to admin_settings_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.settings.delete.setting_deleted' )
+      expect( response.body ).to     have_title I18n.t( 'admin.settings.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.settings.delete.success' )
       expect( response.body ).to     include s1.name
       expect( response.body ).to     include s3.name
       expect( response.body ).not_to include s2.name
@@ -101,8 +101,8 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       expect( response      ).to redirect_to admin_settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.settings.delete.setting_delete_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.settings.delete.failure' )
     end
   end
 
@@ -120,8 +120,8 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       expect( response      ).to     redirect_to admin_settings_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.settings.update.settings_updated' )
+      expect( response.body ).to     have_title I18n.t( 'admin.settings.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.settings.update.success' )
       expect( response.body ).not_to include 'Original value'
       expect( response.body ).to     include 'Updated value'
     end
@@ -139,8 +139,8 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       expect( response      ).to redirect_to admin_settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.settings.index.site_settings' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.settings.update.settings_update_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.settings.update.failure' )
       expect( response.body ).to include s2.value
     end
   end

--- a/spec/request/admin/shared_content_spec.rb
+++ b/spec/request/admin/shared_content_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       get admin_shared_content_path
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
     end
   end
 
@@ -27,8 +27,8 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       expect( response      ).to redirect_to admin_shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.shared_content.create.shared_content_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.shared_content.create.success' )
       expect( response.body ).to include 'new_shared_content'
     end
 
@@ -43,8 +43,8 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       expect( response      ).to redirect_to admin_shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.shared_content.create.shared_content_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.shared_content.create.success' )
       expect( response.body ).to include 'shared_content_is_empty'
     end
 
@@ -59,8 +59,8 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       expect( response      ).to redirect_to admin_shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.shared_content.create.shared_content_created' )
+      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.shared_content.create.success' )
       expect( response.body ).to include 'shared_content_is_null'
     end
 
@@ -73,8 +73,8 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       expect( response      ).to redirect_to admin_shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.shared_content.create.shared_content_create_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.shared_content.create.failure' )
     end
   end
 
@@ -90,8 +90,8 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       expect( response      ).to     redirect_to admin_shared_content_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.shared_content.delete.shared_content_deleted' )
+      expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.shared_content.delete.success' )
       expect( response.body ).to     include s1.name
       expect( response.body ).to     include s3.name
       expect( response.body ).not_to include 'do_not_want'
@@ -104,8 +104,8 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       expect( response      ).to redirect_to admin_shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.shared_content.delete.shared_content_delete_failed' )
+      expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.shared_content.delete.failure' )
     end
   end
 
@@ -125,8 +125,8 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       expect( response      ).to     redirect_to admin_shared_content_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.shared_content.update.shared_content_updated' )
+      expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.shared_content.update.success' )
       expect( response.body ).not_to include 'Original content'
       expect( response.body ).to     include 'Updated content'
     end
@@ -146,8 +146,8 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       expect( response      ).to     redirect_to admin_shared_content_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.shared_content' ).titlecase
-      expect( response.body ).to     have_css '.alert-danger', text: I18n.t( 'admin.shared_content.update.shared_content_update_failed' )
+      expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-danger', text: I18n.t( 'admin.shared_content.update.failure' )
       expect( response.body ).to     include 'Original content'
       expect( response.body ).not_to include 'Updated content'
     end

--- a/spec/request/admin/users_spec.rb
+++ b/spec/request/admin/users_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Admin: Users', type: :request do
         get admin_users_path
 
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.index.list_users' ).titlecase
+        expect( response.body ).to have_title I18n.t( 'admin.users.index.title' ).titlecase
         expect( response.body ).to include user.username
       end
     end
@@ -24,7 +24,7 @@ RSpec.describe 'Admin: Users', type: :request do
         get admin_user_new_path
 
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.new.new_user' ).titlecase
+        expect( response.body ).to have_title I18n.t( 'admin.users.new.title' ).titlecase
       end
     end
 
@@ -35,8 +35,8 @@ RSpec.describe 'Admin: Users', type: :request do
         }
 
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.new.new_user' ).titlecase
-        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.create.user_create_failed' )
+        expect( response.body ).to have_title I18n.t( 'admin.users.new.title' ).titlecase
+        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.create.failure' )
       end
 
       it 'fails when the username collides with an existing username' do
@@ -49,8 +49,8 @@ RSpec.describe 'Admin: Users', type: :request do
         }
 
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.new.new_user' ).titlecase
-        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.create.user_create_failed' )
+        expect( response.body ).to have_title I18n.t( 'admin.users.new.title' ).titlecase
+        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.create.failure' )
       end
 
       it 'adds a new user when the form is submitted' do
@@ -64,8 +64,8 @@ RSpec.describe 'Admin: Users', type: :request do
         expect( response      ).to redirect_to admin_user_path( User.last )
         follow_redirect!
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.edit.edit_user' ).titlecase
-        expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.users.create.user_created' )
+        expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase
+        expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.users.create.success' )
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe 'Admin: Users', type: :request do
         get admin_user_path( user )
 
         expect( response      ).to     have_http_status :ok
-        expect( response.body ).to     have_title I18n.t( 'admin.users.edit.edit_user' ).titlecase
+        expect( response.body ).to     have_title I18n.t( 'admin.users.edit.title' ).titlecase
         expect( response.body ).not_to have_css 'th', text: I18n.t( 'capability.capabilities' )
       end
     end
@@ -90,8 +90,8 @@ RSpec.describe 'Admin: Users', type: :request do
         }
 
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.edit.edit_user' ).titlecase
-        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.update.user_update_failed' )
+        expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase
+        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.update.failure' )
       end
 
       it 'updates the user when the form is submitted' do
@@ -105,8 +105,8 @@ RSpec.describe 'Admin: Users', type: :request do
         expect( response      ).to redirect_to admin_user_path( user )
         follow_redirect!
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.edit.edit_user' ).titlecase
-        expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.users.update.user_updated' )
+        expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase
+        expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.users.update.success' )
         expect( response.body ).to include 'new_username'
       end
     end
@@ -123,8 +123,8 @@ RSpec.describe 'Admin: Users', type: :request do
         expect( response      ).to     redirect_to admin_users_path
         follow_redirect!
         expect( response      ).to     have_http_status :ok
-        expect( response.body ).to     have_title I18n.t( 'admin.users.index.list_users' ).titlecase
-        expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.users.delete.user_deleted' )
+        expect( response.body ).to     have_title I18n.t( 'admin.users.index.title' ).titlecase
+        expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.users.delete.success' )
         expect( response.body ).to     include u1.username
         expect( response.body ).not_to include u2.username
         expect( response.body ).to     include u3.username
@@ -137,8 +137,8 @@ RSpec.describe 'Admin: Users', type: :request do
         expect( response      ).to redirect_to admin_users_path
         follow_redirect!
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.index.list_users' ).titlecase
-        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.delete.user_delete_failed' )
+        expect( response.body ).to have_title I18n.t( 'admin.users.index.title' ).titlecase
+        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.delete.failure' )
       end
     end
   end
@@ -156,7 +156,7 @@ RSpec.describe 'Admin: Users', type: :request do
         get admin_user_path( user )
 
         expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title I18n.t( 'admin.users.edit.edit_user' ).titlecase
+        expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase
         expect( response.body ).to have_css 'th', text: I18n.t( 'capability.capabilities' )
       end
     end
@@ -177,8 +177,8 @@ RSpec.describe 'Admin: Users', type: :request do
       expect( response      ).to redirect_to admin_user_path( user )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.users.edit.edit_user' ).titlecase
-      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.users.update.user_updated' )
+      expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'admin.users.update.success' )
       expect( response.body ).to have_field field_name, with: 'on'
       user.reload
       expect( user.capabilities.length ).to eq 1

--- a/spec/request/admin_spec.rb
+++ b/spec/request/admin_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Admin', type: :request do
       expect( response      ).to redirect_to admin_pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.index.list_pages' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
     end
 
     it 'still works with an admin IP list set' do
@@ -28,7 +28,7 @@ RSpec.describe 'Admin', type: :request do
       expect( response      ).to redirect_to admin_pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_title I18n.t( 'admin.pages.index.list_pages' ).titlecase
+      expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
     end
 
     it 'fails with a blocking admin IP list set' do


### PR DESCRIPTION
Change all the create/update/delete success/failure messages to have success/failure as the key, and the page titles to all have title as the key. Consistency FTW.