### PR TITLE
Refactor: resourceful(ish) routes

### DIFF
--- a/app/controllers/admin/blog/posts_controller.rb
+++ b/app/controllers/admin/blog/posts_controller.rb
@@ -22,7 +22,7 @@ class Admin::Blog::PostsController < AdminController
 
     if @post.save
       flash[ :notice ] = t( '.success' )
-      redirect_to action: :edit, id: @post.id
+      redirect_to action: :edit, blog_id: @blog.id, id: @post.id
     else
       flash.now[ :alert ] = t( '.failure' )
       render action: :new
@@ -69,7 +69,7 @@ class Admin::Blog::PostsController < AdminController
     @post = @blog.posts.find( params[:id] )
   rescue ActiveRecord::RecordNotFound
     skip_authorization
-    redirect_with_alert admin_blog_posts_path, t( '.failure' )
+    redirect_with_alert blog_posts_path, t( '.failure' )
   end
 
   def post_params

--- a/app/controllers/admin/blogs_controller.rb
+++ b/app/controllers/admin/blogs_controller.rb
@@ -56,7 +56,7 @@ class Admin::BlogsController < AdminController
     @blog = Blog.find( params[:id] )
   rescue ActiveRecord::RecordNotFound
     skip_authorization
-    redirect_with_alert admin_blogs_path, t( '.failure' )
+    redirect_with_alert blogs_path, t( '.failure' )
   end
 
   def blog_params

--- a/app/controllers/admin/pages/sections_controller.rb
+++ b/app/controllers/admin/pages/sections_controller.rb
@@ -5,7 +5,7 @@ class Admin::Pages::SectionsController < AdminController
   # Redirect to the combined page+section list
   def index
     skip_authorization
-    redirect_to admin_pages_path
+    redirect_to pages_path
   end
 
   def new
@@ -44,14 +44,14 @@ class Admin::Pages::SectionsController < AdminController
     end
   end
 
-  def delete
+  def destroy
     section = PageSection.find( params[:id] )
     authorise section
 
     flash[ :notice ] = t( '.success' ) if section.destroy
-    redirect_to admin_pages_path
+    redirect_to pages_path
   rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordNotFound
-    redirect_with_alert admin_pages_path, t( '.failure' )
+    redirect_with_alert pages_path, t( '.failure' )
   end
 
   private

--- a/app/controllers/admin/pages/templates_controller.rb
+++ b/app/controllers/admin/pages/templates_controller.rb
@@ -47,14 +47,14 @@ class Admin::Pages::TemplatesController < AdminController
     end
   end
 
-  def delete
+  def destroy
     template = PageTemplate.find( params[:id] )
     authorise template
 
     flash[ :notice ] = t( '.success' ) if template.destroy
-    redirect_to admin_pages_templates_path
+    redirect_to page_templates_path
   rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordNotFound
-    redirect_with_alert admin_pages_templates_path, t( '.failure' )
+    redirect_with_alert page_templates_path, t( '.failure' )
   end
 
   private

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -50,14 +50,14 @@ class Admin::PagesController < AdminController
     end
   end
 
-  def delete
+  def destroy
     page = Page.find( params[:id] )
     authorise page
 
     flash[ :notice ] = t( '.success' ) if page.destroy
-    redirect_to admin_pages_path
+    redirect_to pages_path
   rescue ActiveRecord::RecordNotFound, ActiveRecord::NotNullViolation
-    redirect_with_alert admin_pages_path, t( '.failure' )
+    redirect_with_alert pages_path, t( '.failure' )
   end
 
   private

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -14,7 +14,7 @@ class Admin::SettingsController < AdminController
     else
       flash[ :alert ] = t( '.failure' )
     end
-    redirect_to admin_settings_path
+    redirect_to settings_path
   end
 
   # Main form submitted; update any changed settings and report back
@@ -26,16 +26,16 @@ class Admin::SettingsController < AdminController
     else
       flash[ :alert ] = t( '.failure' )
     end
-    redirect_to admin_settings_path
+    redirect_to settings_path
   end
 
-  def delete
+  def destroy
     setting = Setting.find( params[:id] )
 
     flash[ :notice ] = t( '.success' ) if setting.destroy
-    redirect_to admin_settings_path
+    redirect_to settings_path
   rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordNotFound
-    redirect_with_alert admin_settings_path, t( '.failure' )
+    redirect_with_alert settings_path, t( '.failure' )
   end
 
   private

--- a/app/controllers/admin/shared_content_controller.rb
+++ b/app/controllers/admin/shared_content_controller.rb
@@ -22,7 +22,7 @@ class Admin::SharedContentController < AdminController
     else
       flash[ :alert ] = t( '.failure' )
     end
-    redirect_to admin_shared_content_path
+    redirect_to shared_content_path
   end
 
   # Main form submitted; update existing shared content
@@ -35,22 +35,22 @@ class Admin::SharedContentController < AdminController
     @shared_content.elements_attributes = shared_content_params
 
     flash[ :notice ] = t( '.success' ) if @shared_content.valid?
-    redirect_to admin_shared_content_path
+    redirect_to shared_content_path
   rescue ActiveRecord::RecordNotUnique
     skip_authorization
-    redirect_to admin_shared_content_path,
+    redirect_to shared_content_path,
                 alert: t( '.failure' )
   end
 
-  def delete
+  def destroy
     element = SharedContentElement.find( params[ :id ] )
 
     authorise element
 
     flash[ :notice ] = t( '.success' ) if element.destroy
-    redirect_to admin_shared_content_path
+    redirect_to shared_content_path
   rescue ActiveRecord::NotNullViolation, ActiveRecord::RecordNotFound
-    redirect_with_alert admin_shared_content_path, t( '.failure' )
+    redirect_with_alert shared_content_path, t( '.failure' )
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -44,14 +44,14 @@ class Admin::UsersController < AdminController
     end
   end
 
-  def delete
+  def destroy
     user = User.find( params[:id] )
     authorise user
 
     flash[ :notice ] = t( '.success' ) if user.destroy
-    redirect_to admin_users_path
+    redirect_to users_path
   rescue ActiveRecord::RecordNotFound, ActiveRecord::NotNullViolation
-    redirect_with_alert admin_users_path, t( '.failure' )
+    redirect_with_alert users_path, t( '.failure' )
   end
 
   private

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -19,13 +19,13 @@ class AdminController < ApplicationController
     # of which one seems most likely to be useful if they have access to many)
     # TODO: Add a user-setting so admins can set their preferred landing page
     if current_user.can? :list, :pages
-      redirect_to admin_pages_path
+      redirect_to pages_path
     elsif current_user.can? :list, :blogs
-      redirect_to admin_blogs_path
+      redirect_to blogs_path
     elsif current_user.can? :list, :users
-      redirect_to admin_users_path
+      redirect_to users_path
     elsif current_user.can? :list, :settings
-      redirect_to admin_settings_path
+      redirect_to settings_path
     end
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/policies/admin/default_policy.rb
+++ b/app/policies/admin/default_policy.rb
@@ -38,10 +38,6 @@ class Admin::DefaultPolicy < DefaultPolicy
     update?
   end
 
-  def delete?
-    @this_user.can? :delete, @record.class.name.underscore.pluralize.to_sym
-  end
-
   def destroy?
     @this_user.can? :destroy, @record.class.name.underscore.pluralize.to_sym
   end

--- a/app/policies/admin/shared_content_element_policy.rb
+++ b/app/policies/admin/shared_content_element_policy.rb
@@ -4,7 +4,7 @@ class Admin::SharedContentElementPolicy < Admin::DefaultPolicy
     @this_user.can? :add, :shared_content
   end
 
-  def delete?
-    @this_user.can? :delete, :shared_content
+  def destroy?
+    @this_user.can? :destroy, :shared_content
   end
 end

--- a/app/views/admin/blog/posts/edit.html.erb
+++ b/app/views/admin/blog/posts/edit.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @post, url: admin_blog_post_path, method: :put do |f| %>
+<%= form_for @post, url: blog_post_path( @post.blog ), method: :put do |f| %>
   <p>
     <%= f.label :title %><br>
     <%= f.text_field :title %>

--- a/app/views/admin/blog/posts/index.html.erb
+++ b/app/views/admin/blog/posts/index.html.erb
@@ -32,8 +32,8 @@
       </td>
       <td class="actions">
         <%= link_to t( 'view'   ), view_blog_post_path( post ) %>
-        <%= link_to t( 'edit'   ), edit_admin_blog_post_path( post ) %>
-        <%= link_to t( 'delete' ), admin_blog_post_path( post ),
+        <%= link_to t( 'edit'   ), edit_blog_post_path( post.blog, post ) %>
+        <%= link_to t( 'delete' ), blog_post_path( post.blog, post ),
             method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
   		</td>
     </tr>

--- a/app/views/admin/blog/posts/new.html.erb
+++ b/app/views/admin/blog/posts/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @post, url: admin_blog_posts_path, method: :post do |f| %>
+<%= form_for @post, url: create_blog_post_path( @post.blog ), method: :post do |f| %>
   <p>
     <%= f.label :title %><br>
     <%= f.text_field :title %>

--- a/app/views/admin/blogs/edit.html.erb
+++ b/app/views/admin/blogs/edit.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @blog, url: admin_blog_path, method: :put do |f| %>
+<%= form_for @blog, url: blog_path, method: :put do |f| %>
   <p>
     <%= f.label :name %><br>
     <%= f.text_field :name %>

--- a/app/views/admin/blogs/index.html.erb
+++ b/app/views/admin/blogs/index.html.erb
@@ -25,12 +25,12 @@
       </td>
       <td class="actions">
         <% if Blog.multiple_blogs_mode %>
-        <%= link_to t( 'view'   ), blog_path( blog ) %>
+        <%= link_to t( 'view'   ), view_blog_path( blog ) %>
         <% else %>
-        <%= link_to t( 'view'   ), blog_path %>
+        <%= link_to t( 'view'   ), view_blog_path %>
         <% end %>
-        <%= link_to t( 'edit'   ), edit_admin_blog_path( blog ) %>
-        <%= link_to t( 'delete' ), admin_blog_path( blog ),
+        <%= link_to t( 'edit'   ), edit_blog_path( blog ) %>
+        <%= link_to t( 'delete' ), blog_path( blog ),
             method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
       </td>
     </tr>

--- a/app/views/admin/blogs/new.html.erb
+++ b/app/views/admin/blogs/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @blog, url: admin_blogs_path, method: :post do |f| %>
+<%= form_for @blog, url: create_blog_path, method: :post do |f| %>
   <p>
     <%= f.label :name %><br>
     <%= f.text_field :name %>

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -5,8 +5,14 @@
 
     <%# TODO: handle nested controllers, e.g. Pages::Sections %>
 
+    <% if controller_name == 'posts' %> <%# SO MuCH BODGE :( %>
+    <li class="breadcrumb-item"><%= link_to 'Blog',  blogs_path %></li>
+    <li class="breadcrumb-item"><%= link_to 'Posts', blog_posts_path( @blog ) %></li>
+    <li class="breadcrumb-item active"><%= @page_title.titlecase %></li>
+    <% else %>
     <li class="breadcrumb-item"><%= link_to controller_name.titlecase,
         url_for( controller: controller_name, only_path: false ) %></li>
     <li class="breadcrumb-item active"><%= @page_title.titlecase %></li>
+    <% end %>
   </ol>
 </nav>

--- a/app/views/admin/menu/_menu.html.erb
+++ b/app/views/admin/menu/_menu.html.erb
@@ -1,19 +1,16 @@
 <%# NTS: CoreUI free icons: https://coreui.io/icons/free/ %>
 <ul class="c-sidebar-nav">
-  <%= render partial: 'admin/menu/menu__item', locals:
-      { text: 'Dashboard', link: admin_path, icon: 'speedometer' } %>
+  <%= render_admin_menu_item( 'Dashboard', admin_path, 'speedometer' ) %>
 
   <%= render partial: 'admin/menu/menu_pages' %>
 
-  <%= render partial: 'admin/menu/menu__item', locals:
-      { text: 'Shared content', link: admin_shared_content_path, icon: 'list' } %>
+  <%= render_admin_menu_item( 'Shared content', shared_content_path, 'list' ) %>
 
   <%= render partial: 'admin/menu/menu_blogs' %>
 
   <%= render partial: 'admin/menu/menu_users' %>
 
-  <%= render partial: 'admin/menu/menu__item', locals:
-      { text: 'Settings', link: admin_settings_path, icon: 'settings' } %>
+  <%= render_admin_menu_item( 'Settings', settings_path, 'settings' ) %>
 </ul>
 
 <script>

--- a/app/views/admin/menu/_menu_blogs.html.erb
+++ b/app/views/admin/menu/_menu_blogs.html.erb
@@ -5,13 +5,13 @@
     <% elsif Blog.count == 0 %>
     <%= render_admin_menu_item( 'Create blog', new_blog_path, 'library-add' ) %>
     <% else %>
-    <%= render_admin_menu_item( 'Edit blog details', edit_admin_blog_path( Blog.first ), 'library' ) %>
+    <%= render_admin_menu_item( 'Edit blog details', edit_blog_path( Blog.first ), 'library' ) %>
     <% end %>
 
     <% if Blog.count > 0 %>
     <% if BlogPost.count > 0 %>
     <%= render_admin_menu_item( 'List blog posts', blog_posts_path, 'list' ) %>
     <% end %>
-    <%= render_admin_menu_item( 'Add new blog post', new_blog_post_path, 'pencil' ) %>
+    <%= render_admin_menu_item( 'Add new blog post', new_blog_post_path( Blog.first ), 'pencil' ) %>
     <% end %>
   <%= render_admin_menu_section_end %>

--- a/app/views/admin/menu/_menu_blogs.html.erb
+++ b/app/views/admin/menu/_menu_blogs.html.erb
@@ -1,19 +1,17 @@
   <%= render_admin_menu_section_start( 'Blogs', 'rss' ) %>
+    <% if Blog.multiple_blogs_mode %>
+    <%= render_admin_menu_item( 'List blogs', blogs_path, 'library' ) %>
+    <%= render_admin_menu_item( 'Add new blog', new_blog_path, 'library-add' ) %>
+    <% elsif Blog.count == 0 %>
+    <%= render_admin_menu_item( 'Create blog', new_blog_path, 'library-add' ) %>
+    <% else %>
+    <%= render_admin_menu_item( 'Edit blog details', edit_admin_blog_path( Blog.first ), 'library' ) %>
+    <% end %>
 
-  <% if Blog.multiple_blogs_mode %>
-  <%= render_admin_menu_item( 'List blogs', admin_blogs_path, 'library' ) %>
-  <%= render_admin_menu_item( 'Add new blog', new_admin_blog_path, 'library-add' ) %>
-  <% elsif Blog.count == 0 %>
-  <%= render_admin_menu_item( 'Create blog', new_admin_blog_path, 'library-add' ) %>
-  <% else %>
-  <%= render_admin_menu_item( 'Edit blog details', edit_admin_blog_path( Blog.first ), 'library' ) %>
-  <% end %>
-
-  <% if Blog.count > 0 %>
-  <% if BlogPost.count > 0 %>
-  <%= render_admin_menu_item( 'List blog posts', admin_blog_posts_path, 'list' ) %>
-  <% end %>
-  <%= render_admin_menu_item( 'Add new blog post', new_admin_blog_post_path, 'pencil' ) %>
-  <% end %>
-
+    <% if Blog.count > 0 %>
+    <% if BlogPost.count > 0 %>
+    <%= render_admin_menu_item( 'List blog posts', blog_posts_path, 'list' ) %>
+    <% end %>
+    <%= render_admin_menu_item( 'Add new blog post', new_blog_post_path, 'pencil' ) %>
+    <% end %>
   <%= render_admin_menu_section_end %>

--- a/app/views/admin/menu/_menu_pages.html.erb
+++ b/app/views/admin/menu/_menu_pages.html.erb
@@ -1,13 +1,7 @@
-  <%= render partial: 'admin/menu/menu__section_start', locals:
-      { text: 'Pages', icon: 'list-rich' } %>
-      <%= render partial: 'admin/menu/menu__item', locals:
-          { text: 'List pages', link: admin_pages_path, icon: 'list-rich' } %>
-      <%= render partial: 'admin/menu/menu__item', locals:
-          { text: 'Add new page', link: admin_page_new_path, icon: 'playlist-add' } %>
-      <%= render partial: 'admin/menu/menu__item', locals:
-          { text: 'Add new section', link: admin_pages_section_new_path, icon: 'playlist-add' } %>
-      <%= render partial: 'admin/menu/menu__item', locals:
-          { text: 'List templates', link: admin_pages_templates_path, icon: 'library' } %>
-      <%= render partial: 'admin/menu/menu__item', locals:
-          { text: 'Add new template', link: admin_pages_template_new_path, icon: 'library-add' } %>
-  <%= render partial: 'admin/menu/menu__section_end' %>
+  <%= render_admin_menu_section_start( 'Pages', 'list-rich' ) %>
+    <%= render_admin_menu_item( 'List pages', pages_path, 'list-rich' ) %>
+    <%= render_admin_menu_item( 'New page', new_page_path, 'playlist-add' ) %>
+    <%= render_admin_menu_item( 'New section', new_page_section_path, 'playlist-add' ) %>
+    <%= render_admin_menu_item( 'List page templates', page_templates_path, 'library' ) %>
+    <%= render_admin_menu_item( 'New page template', new_page_template_path, 'library-add' ) %>
+  <%= render_admin_menu_section_end %>

--- a/app/views/admin/menu/_menu_users.html.erb
+++ b/app/views/admin/menu/_menu_users.html.erb
@@ -1,7 +1,4 @@
-  <%= render partial: 'admin/menu/menu__section_start', locals:
-      { text: 'Users', icon: 'people' } %>
-      <%= render partial: 'admin/menu/menu__item', locals:
-          { text: 'List users', link: admin_users_path, icon: 'people' } %>
-      <%= render partial: 'admin/menu/menu__item', locals:
-          { text: 'Add new user', link: admin_user_new_path, icon: 'user-follow' } %>
-  <%= render partial: 'admin/menu/menu__section_end' %>
+  <%= render_admin_menu_section_start( 'Users', 'people' ) %>
+    <%= render_admin_menu_item( 'List users', users_path, 'people' ) %>
+    <%= render_admin_menu_item( 'Add new user', new_user_path, 'user-follow' ) %>
+  <%= render_admin_menu_section_end %>

--- a/app/views/admin/pages/_section_contents.html.erb
+++ b/app/views/admin/pages/_section_contents.html.erb
@@ -12,8 +12,8 @@
     </td>
     <td class="actions">
       <%= link_to t( 'view'   ), view_path %>
-      <%= link_to t( 'edit'   ), admin_pages_section_path( section ) %>
-      <%= link_to t( 'delete' ), admin_pages_section_delete_path( section ),
+      <%= link_to t( 'edit'   ), edit_page_section_path( section ) %>
+      <%= link_to t( 'delete' ), page_section_path( section ),
           method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
     </td>
   </tr>
@@ -32,8 +32,8 @@
     </td>
     <td class="actions">
       <%= link_to t( 'view'   ), "#{view_path}/#{page.slug}" %>
-      <%= link_to t( 'edit'   ), admin_page_path( page ) %>
-      <%= link_to t( 'delete' ), admin_page_delete_path( page ),
+      <%= link_to t( 'edit'   ), edit_page_path( page ) %>
+      <%= link_to t( 'delete' ), page_path( page ),
           method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
     </td>
   </tr>

--- a/app/views/admin/pages/edit.html.erb
+++ b/app/views/admin/pages/edit.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @page, url: page_path( @page ), method: :post do |f| %>
+<%= form_for @page, url: page_path( @page ), method: :put do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>

--- a/app/views/admin/pages/edit.html.erb
+++ b/app/views/admin/pages/edit.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @page, url: admin_page_path( @page ), method: :post do |f| %>
+<%= form_for @page, url: page_path( @page ), method: :post do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>
@@ -38,6 +38,6 @@
     <%= render partial: 'admin/pages/page_element', locals: { fields: fields, content: :content, name: @page.elements[fields.index].name, content_type: @page.elements[fields.index].content_type, filenames: select_filenames } %>
   <% end %>
   <p class="top-margin">
-    <%= submit_tag t( 'update' ) %>
+    <%= f.submit t( 'update' ) %>
   </p>
 <% end %>

--- a/app/views/admin/pages/index.html.erb
+++ b/app/views/admin/pages/index.html.erb
@@ -28,8 +28,8 @@
     </td>
 		<td class="actions">
       <%= link_to t( 'view' ), url_for( "/pages/#{page.slug}" )   %>
-      <%= link_to t( 'edit' ), url_for( admin_page_path( page ) ) %>
-      <%= link_to t( 'delete' ), admin_page_delete_path( page ),
+      <%= link_to t( 'edit' ), url_for( edit_page_path( page ) ) %>
+      <%= link_to t( 'delete' ), page_path( page ),
           method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
 		</td>
 	</tr>

--- a/app/views/admin/pages/new.html.erb
+++ b/app/views/admin/pages/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for :page, url: admin_page_new_path, method: :post do |f| %>
+<%= form_for :page, url: create_page_path, method: :post do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>
@@ -35,6 +35,6 @@
     <br><%= f.check_box :hidden %>
   </p>
   <p class="top-margin">
-    <%= submit_tag t( 'add' ) %>
+    <%= f.submit t( 'add' ) %>
   </p>
 <% end %>

--- a/app/views/admin/pages/sections/edit.html.erb
+++ b/app/views/admin/pages/sections/edit.html.erb
@@ -1,7 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-
-<%= form_for @section, url: admin_pages_section_path( @section ), method: :post do |f| %>
+<%= form_for @section, url: page_section_path( @section ), method: :put do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>

--- a/app/views/admin/pages/sections/new.html.erb
+++ b/app/views/admin/pages/sections/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for :page_section, url: admin_pages_section_new_path, method: :post do |f| %>
+<%= form_for :page_section, url: create_page_section_path, method: :post do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>
@@ -31,6 +31,6 @@
     <br><%= f.check_box :hidden %>
   </p>
   <p class="top-margin">
-    <%= submit_tag t( 'add' ) %>
+    <%= f.submit t( 'add' ) %>
   </p>
 <% end %>

--- a/app/views/admin/pages/templates/edit.html.erb
+++ b/app/views/admin/pages/templates/edit.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @template, url: admin_pages_template_path( @template ), method: :put do |f| %>
+<%= form_for @template, url: page_template_path( @template ), method: :put do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>

--- a/app/views/admin/pages/templates/edit.html.erb
+++ b/app/views/admin/pages/templates/edit.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @template, url: admin_pages_template_path( @template ), method: :post do |f| %>
+<%= form_for @template, url: admin_pages_template_path( @template ), method: :put do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>

--- a/app/views/admin/pages/templates/index.html.erb
+++ b/app/views/admin/pages/templates/index.html.erb
@@ -18,8 +18,8 @@
 			<%= template.name %>
 		</td>
 		<td class="actions">
-			<%= link_to t( 'edit' ), url_for( admin_pages_template_path( template ) ) %>
-      <%= link_to t( 'delete' ), admin_pages_template_delete_path( template ),
+			<%= link_to t( 'edit' ), edit_page_template_path( template ) %>
+      <%= link_to t( 'delete' ), page_template_path( template ),
           method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
 		</td>
 	</tr>

--- a/app/views/admin/pages/templates/new.html.erb
+++ b/app/views/admin/pages/templates/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for :page_template, url: admin_pages_template_new_path, method: :post do |f| %>
+<%= form_for :page_template, url: create_page_template_path, method: :post do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_with name: 'all_settings', url: admin_settings_path, method: :post do %>
+<%= form_with name: 'all_settings', url: settings_path, method: :post do %>
 <table class="table table-responsive-sm table-striped">
   <thead>
     <tr>
@@ -30,7 +30,7 @@
       <%= text_field :settings, "setting_description_#{s.id}", value: s.description, class: 'textlong' %>
     </td>
 		<td class="actions">
-      <%= link_to t( 'delete' ), admin_setting_delete_path( s ),
+      <%= link_to t( 'delete' ), setting_delete_path( s ),
           method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
 		</td>
 	</tr>
@@ -41,7 +41,7 @@
 </p>
 <% end  # form %>
 
-<%= form_for :setting, name: 'new_setting', url: admin_setting_create_path, method: :post do |f2| %>
+<%= form_for :setting, name: 'new_setting', url: setting_create_path, method: :post do |f2| %>
   <fieldset>
     <legend>
       Add new setting

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -41,7 +41,7 @@
 </p>
 <% end  # form %>
 
-<%= form_for :setting, name: 'new_setting', url: setting_create_path, method: :post do |f2| %>
+<%= form_for :setting, name: 'new_setting', url: create_setting_path, method: :post do |f2| %>
   <fieldset>
     <legend>
       Add new setting

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_with name: 'all_settings', url: settings_path, method: :post do %>
+<%= form_with name: 'all_settings', url: settings_path, method: :put do %>
 <table class="table table-responsive-sm table-striped">
   <thead>
     <tr>
@@ -30,7 +30,7 @@
       <%= text_field :settings, "setting_description_#{s.id}", value: s.description, class: 'textlong' %>
     </td>
 		<td class="actions">
-      <%= link_to t( 'delete' ), setting_delete_path( s ),
+      <%= link_to t( 'delete' ), delete_setting_path( s ),
           method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
 		</td>
 	</tr>
@@ -41,7 +41,7 @@
 </p>
 <% end  # form %>
 
-<%= form_for :setting, name: 'new_setting', url: create_setting_path, method: :post do |f2| %>
+<%= form_for :setting, name: 'new_setting', url: setting_path, method: :post do |f2| %>
   <fieldset>
     <legend>
       Add new setting

--- a/app/views/admin/shared_content/_element.html.erb
+++ b/app/views/admin/shared_content/_element.html.erb
@@ -14,7 +14,7 @@
     <% end %>
   </td>
   <td class="actions">
-    <%= link_to t( 'delete' ), admin_shared_content_delete_path( fields.object ),
+    <%= link_to t( 'delete' ), delete_shared_content_path( fields.object ),
         method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
   </td>
 </tr>

--- a/app/views/admin/shared_content/index.html.erb
+++ b/app/views/admin/shared_content/index.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_with model: @shared_content, name: 'shared_content', url: admin_shared_content_path, method: :post do |f| %>
+<%= form_with model: @shared_content, name: 'shared_content', url: shared_content_path, method: :put do |f| %>
 <table class="table table-responsive-sm table-striped">
   <%= f.fields_for :elements do |fields| %>
     <%= render partial: 'element', locals: {
@@ -16,7 +16,7 @@
 </p>
 <% end %>
 
-<%= form_for :shared_content_element, name: 'new_element', url: admin_shared_content_create_path, method: :post do |f2| %>
+<%= form_for :shared_content_element, name: 'new_element', url: shared_content_path, method: :post do |f2| %>
   <fieldset>
     <legend>
       Add new shared content

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @user, url: user_path( @user ), method: :post do |f| %>
+<%= form_for @user, url: user_path( @user ), method: :put do |f| %>
   <p>
     <%= f.label :username %>
     <br><%= f.text_field :username %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for @user, url: admin_user_path( @user ), method: :post do |f| %>
+<%= form_for @user, url: user_path( @user ), method: :post do |f| %>
   <p>
     <%= f.label :username %>
     <br><%= f.text_field :username %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -27,8 +27,8 @@
   		</td>
   		<td class="actions">
         <%= link_to t( 'view'   ), user_profile_path( user.username ) %>
-        <%= link_to t( 'edit'   ), admin_user_path( user ) %>
-        <%= link_to t( 'delete' ), admin_user_delete_path( user ),
+        <%= link_to t( 'edit'   ), user_path( user ) %>
+        <%= link_to t( 'delete' ), user_path( user ),
             method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
   		</td>
   	</tr>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -27,7 +27,7 @@
   		</td>
   		<td class="actions">
         <%= link_to t( 'view'   ), user_profile_path( user.username ) %>
-        <%= link_to t( 'edit'   ), user_path( user ) %>
+        <%= link_to t( 'edit'   ), edit_user_path( user ) %>
         <%= link_to t( 'delete' ), user_path( user ),
             method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
   		</td>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for :user, url: admin_user_new_path, method: :post do |f| %>
+<%= form_for :user, url: create_user_path, method: :post do |f| %>
   <p>
     <%= f.label :username %>
     <br><%= f.text_field :username %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,7 +216,7 @@ en:
         success: Shared content updated
         # unchanged: Shared content unchanged
         failure: Failed to update shared content
-      delete:
+      destroy:
         success: Specified shared content deleted
         failure: Failed to delete specified shared content
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,7 @@ en:
       update:
         success: Page details updated
         failure: Failed to update page details
-      delete:
+      destroy:
         success: Page deleted
         failure: Failed to delete page
 
@@ -163,7 +163,7 @@ en:
         update:
           success: Section details updated
           failure: Failed to update section details
-        delete:
+        destroy:
           success: Section deleted
           failure: Failed to section page
 
@@ -180,7 +180,7 @@ en:
         update:
           success: Template details updated
           failure: Failed to update template details
-        delete:
+        destroy:
           success: Template deleted
           failure: Failed to delete template
 
@@ -233,7 +233,7 @@ en:
       update:
         success: User details updated
         failure: Failed to update user details
-      delete:
+      destroy:
         success: User deleted
         failure: Failed to delete user
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,7 +200,7 @@ en:
         success: Settings updated
         # unchanged: Settings unchanged
         failure: Failed to update settings
-      delete:
+      destroy:
         success: Setting deleted
         failure: Failed to delete setting
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,31 +57,33 @@ Rails.application.routes.draw do
     # CKEditor (WYSIWYG editor used on various admin pages)
     mount Ckeditor::Engine => '/admin/ckeditor'
 
+    EXCEPT = %w[ index show create ].freeze
+
     scope path: 'admin', module: 'admin' do
       # Blogs
       get  :blogs, to: 'blogs#index'
-      post :blog,  to: 'blogs#create'
+      post :blog,  to: 'blogs#create', as: :create_blog
 
-      resources :blog, controller: :blogs, except: %w[ index show create ] do
-        get  :posts, to: 'posts#index'
-        post :post,  to: 'posts#create'
-        resources :post, controller: :posts, except: %w[ index show create ]
+      resources :blog, controller: :blogs, except: EXCEPT do
+        get :posts, to: 'posts#index'
+        resources :post, controller: :posts, except: EXCEPT
       end
+      post 'blog/:id/post', to: 'blog/posts#create', as: :create_blog_post
 
       # Pages
       get  :pages, to: 'pages#index'
-      post :page,  to: 'pages#create'
-      resources :page, controller: :pages, except: %w[ index show create ]
+      post :page,  to: 'pages#create', as: :create_page
+      resources :page, controller: :pages, except: EXCEPT
 
       scope path: :pages, module: :pages, as: :page do
-        post :section,   to: 'sections#create'
-        resources :section,  controller: :sections,
-                             except: %w[ index show create ]
-        get  :templates, to: 'templates#index'
-        post :template,  to: 'templates#create'
-        resources :template, controller: :templates,
-                             except: %w[ index show create ]
+        resources :section,  controller: :sections, except: EXCEPT
+        get :templates, to: 'templates#index'
+        resources :template, controller: :templates, except: EXCEPT
       end
+      post 'pages/section',   to: 'pages/sections#create',
+                              as: :create_page_section
+      post 'pages/template',  to: 'pages/templates#create',
+                              as: :create_page_template
 
       # Shared Content
       get    'shared-content',        to: 'shared_content#index',
@@ -94,14 +96,14 @@ Rails.application.routes.draw do
 
       # Site settings
       get    'settings',           to: 'settings#index'
-      post   'settings',           to: 'settings#update'
-      post   'setting/create',     to: 'settings#create', as: :setting_create
-      delete 'setting/delete/:id', to: 'settings#delete', as: :setting_delete
+      post   'settings',           to: 'settings#update', as: :update_settings
+      post   'setting/create',     to: 'settings#create', as: :create_setting
+      delete 'setting/delete/:id', to: 'settings#delete', as: :delete_setting
 
       # Users
       get  :users, to: 'users#index'
-      post :user,  to: 'users#create'
-      resources :user, controller: :users, except: %w[ index show create ]
+      post :user,  to: 'users#create', as: :create_user
+      resources :user, controller: :users, except: EXCEPT
     end
 
     # The Ultimate Catch-All Route! Passes through to page handler,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
       resources :page, controller: :pages, except: EXCEPT
 
       scope path: :pages, module: :pages, as: :page do
+        get :sections,  to: 'sections#index'
         resources :section,  controller: :sections, except: EXCEPT
         get :templates, to: 'templates#index'
         resources :template, controller: :templates, except: EXCEPT

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,13 +86,11 @@ Rails.application.routes.draw do
                               as: :create_page_template
 
       # Shared Content
-      get    'shared-content',        to: 'shared_content#index',
-                                      as: :shared_content
-      post   'shared-content',        to: 'shared_content#update'
-      post   'shared-content/create', to: 'shared_content#create',
-                                      as: :shared_content_create
-      delete 'shared-content/:id',    to: 'shared_content#delete',
-                                      as: :shared_content_delete
+      get    'shared-content',      to: 'shared_content#index'
+      put    'shared-content',      to: 'shared_content#update'
+      post   'shared-content',      to: 'shared_content#create'
+      delete 'shared-content/:id',  to: 'shared_content#destroy',
+                                    as: :delete_shared_content
 
       # Site settings
       get    'settings',           to: 'settings#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,18 +85,18 @@ Rails.application.routes.draw do
       post 'pages/template',  to: 'pages/templates#create',
                               as: :create_page_template
 
+      # Site settings
+      get    'settings',    to: 'settings#index'
+      put    'settings',    to: 'settings#update'
+      post   'setting',     to: 'settings#create'
+      delete 'setting/:id', to: 'settings#destroy', as: :delete_setting
+
       # Shared Content
       get    'shared-content',      to: 'shared_content#index'
       put    'shared-content',      to: 'shared_content#update'
       post   'shared-content',      to: 'shared_content#create'
       delete 'shared-content/:id',  to: 'shared_content#destroy',
                                     as: :delete_shared_content
-
-      # Site settings
-      get    'settings',           to: 'settings#index'
-      post   'settings',           to: 'settings#update', as: :update_settings
-      post   'setting/create',     to: 'settings#create', as: :create_setting
-      delete 'setting/delete/:id', to: 'settings#delete', as: :delete_setting
 
       # Users
       get  :users, to: 'users#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,25 +8,27 @@ Rails.application.routes.draw do
     # Blogs
     if Rails.application.config.multiple_blogs_mode
       # :nocov:
-      get 'blogs',                               to: 'blogs#index'
-      get 'blog/:blog_slug',                     to: 'blogs#recent'
-      get 'blog/:blog_slug/:year/:month/:slug',  to: 'blogs#show'
-      get 'blog/:blog_slug/:year/:month',        to: 'blogs#month'
-      get 'blog/:blog_slug/:year',               to: 'blogs#year'
+      get 'blogs',                              to: 'blogs#index',
+                                                as: :view_blogs
+      get 'blog/:blog_slug',                    to: 'blogs#recent',
+                                                as: :view_blog
+      get 'blog/:blog_slug/:year/:month/:slug', to: 'blogs#show',  as: :ignore1
+      get 'blog/:blog_slug/:year/:month',       to: 'blogs#month', as: :ignore2
+      get 'blog/:blog_slug/:year',              to: 'blogs#year',  as: :ignore3
       # :nocov:
     else
-      get 'blog',                     to: 'blogs#recent', as: :blog
-      get 'blog/:year/:month/:slug',  to: 'blogs#show',   as: :blog_post,
+      get 'blog',                     to: 'blogs#recent', as: :view_blog
+      get 'blog/:year/:month/:slug',  to: 'blogs#show',   as: :ignore1,
                                       constraints: {
                                         year: %r{\d\d\d\d},
                                         month: %r{\d\d}
                                       }
-      get 'blog/:year/:month',        to: 'blogs#month',  as: :blog_month,
+      get 'blog/:year/:month',        to: 'blogs#month',  as: :ignore2,
                                       constraints: {
                                         year: %r{\d\d\d\d},
                                         month: %r{\d\d}
                                       }
-      get 'blog/:year',               to: 'blogs#year',   as: :blog_year,
+      get 'blog/:year',               to: 'blogs#year',   as: :ignore3,
                                       constraints: { year: %r{\d\d\d\d} }
     end
 
@@ -46,10 +48,10 @@ Rails.application.routes.draw do
                   password: '/user/account/password',
                   unlock: '/user/account/unlock'
                 }
-    get 'users',           to: 'users#index', as: :main_site_users_redirect
-    get 'user',            to: 'users#index', as: :main_site_user_redirect
     get 'user/:username',  to: 'users#show',  as: :user_profile,
                            constraints: { username: User::USERNAME_REGEX }
+    get 'user',            to: 'users#index', as: :user_redirect
+    get 'users',           to: 'users#index', as: :users_redirect
 
     # ========== ( Admin area ) ==========
     get 'admin', to: 'admin#index'
@@ -64,9 +66,9 @@ Rails.application.routes.draw do
       get  :blogs, to: 'blogs#index'
       post :blog,  to: 'blogs#create', as: :create_blog
 
-      resources :blog, controller: :blogs, except: EXCEPT do
-        get :posts, to: 'posts#index'
-        resources :post, controller: :posts, except: EXCEPT
+      resources :blog, controller: :blogs, as: :blog, except: EXCEPT do
+        get :posts, to: 'blog/posts#index'
+        resources :post, controller: 'blog/posts', except: EXCEPT
       end
       post 'blog/:id/post', to: 'blog/posts#create', as: :create_blog_post
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,6 @@ Rails.application.routes.draw do
     # ========== ( Main site ) ==========
     root to: 'pages#index'
 
-    # Pages
-    get 'pages',       to: 'pages#index'
-    get 'pages/*path', to: 'pages#show'
-
     # Blogs
     if Rails.application.config.multiple_blogs_mode
       # :nocov:
@@ -50,10 +46,9 @@ Rails.application.routes.draw do
                   password: '/user/account/password',
                   unlock: '/user/account/unlock'
                 }
-    get 'users',           to: 'users#index'
-    get 'user',            to: 'users#index'
-    get 'user/:username',  to: 'users#show',
-                           as: :user_profile,
+    get 'users',           to: 'users#index', as: :main_site_users_redirect
+    get 'user',            to: 'users#index', as: :main_site_user_redirect
+    get 'user/:username',  to: 'users#show',  as: :user_profile,
                            constraints: { username: User::USERNAME_REGEX }
 
     # ========== ( Admin area ) ==========
@@ -62,47 +57,36 @@ Rails.application.routes.draw do
     # CKEditor (WYSIWYG editor used on various admin pages)
     mount Ckeditor::Engine => '/admin/ckeditor'
 
-    namespace :admin do
-      # Pages
-      get    'pages',          to: 'pages#index'
-      get    'page/new',       to: 'pages#new'
-      post   'page/new',       to: 'pages#create'
-      get    'page/:id',       to: 'pages#edit',       as: :page
-      post   'page/:id',       to: 'pages#update'
-      delete 'page/:id',       to: 'pages#delete',     as: :page_delete
-
-      namespace :pages do
-        # Page sections
-        get    'sections',     to: 'sections#index'
-        get    'section/new',  to: 'sections#new'
-        post   'section/new',  to: 'sections#create'
-        get    'section/:id',  to: 'sections#edit',    as: :section
-        post   'section/:id',  to: 'sections#update'
-        delete 'section/:id',  to: 'sections#delete',  as: :section_delete
-
-        # Page templates
-        get    'templates',    to: 'templates#index'
-        get    'template/new', to: 'templates#new'
-        post   'template/new', to: 'templates#create'
-        get    'template/:id', to: 'templates#edit',   as: :template
-        post   'template/:id', to: 'templates#update'
-        delete 'template/:id', to: 'templates#delete', as: :template_delete
-      end
-
+    scope path: 'admin', module: 'admin' do
       # Blogs
-      resources :blogs
-      namespace :blog do
+      resources :blog
+      resources :blog do
         resources :posts
       end
 
+      # Pages
+      get  :pages, to: 'pages#index'
+      post :page,  to: 'pages#create'
+      resources :page, controller: :pages, except: %w[ index show create ]
+
+      scope path: :pages, module: :pages, as: :page do
+        post :section,   to: 'sections#create'
+        resources :section,  controller: :sections,
+                             except: %w[ index show create ]
+        get  :templates, to: 'templates#index'
+        post :template,  to: 'templates#create'
+        resources :template, controller: :templates,
+                             except: %w[ index show create ]
+      end
+
       # Shared Content
-      get    'shared-content',            to: 'shared_content#index',
-                                          as: :shared_content
-      post   'shared-content',            to: 'shared_content#update'
-      post   'shared-content/create',     to: 'shared_content#create',
-                                          as: :shared_content_create
-      delete 'shared-content/delete/:id', to: 'shared_content#delete',
-                                          as: :shared_content_delete
+      get    'shared-content',        to: 'shared_content#index',
+                                      as: :shared_content
+      post   'shared-content',        to: 'shared_content#update'
+      post   'shared-content/create', to: 'shared_content#create',
+                                      as: :shared_content_create
+      delete 'shared-content/:id',    to: 'shared_content#delete',
+                                      as: :shared_content_delete
 
       # Site settings
       get    'settings',           to: 'settings#index'
@@ -111,15 +95,13 @@ Rails.application.routes.draw do
       delete 'setting/delete/:id', to: 'settings#delete', as: :setting_delete
 
       # Users
-      get    'users',    to: 'users#index'
-      get    'user/new', to: 'users#new'
-      post   'user/new', to: 'users#create'
-      get    'user/:id', to: 'users#edit',   as: :user
-      post   'user/:id', to: 'users#update'
-      delete 'user/:id', to: 'users#delete', as: :user_delete
+      get  :users, to: 'users#index'
+      post :user,  to: 'users#create'
+      resources :user, controller: :users, except: %w[ index show create ]
     end
 
-    # The Ultimate Catch-All Route - passes through to page handler
+    # The Ultimate Catch-All Route! Passes through to page handler,
+    # so that we can have top-level pages - /foo instead of /pages/foo
     get '*path', to: 'pages#show'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,9 +59,13 @@ Rails.application.routes.draw do
 
     scope path: 'admin', module: 'admin' do
       # Blogs
-      resources :blog
-      resources :blog do
-        resources :posts
+      get  :blogs, to: 'blogs#index'
+      post :blog,  to: 'blogs#create'
+
+      resources :blog, controller: :blogs, except: %w[ index show create ] do
+        get  :posts, to: 'posts#index'
+        post :post,  to: 'posts#create'
+        resources :post, controller: :posts, except: %w[ index show create ]
       end
 
       # Pages

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -66,36 +66,36 @@ seed Capability, { name: 'edit',          category: blog_posts_cc }
 seed Capability, { name: 'destroy',       category: blog_posts_cc }
 seed Capability, { name: 'change_author', category: blog_posts_cc }
 # Pages
-seed Capability, { name: 'list',   category: pages_cc }
-seed Capability, { name: 'add',    category: pages_cc }
-seed Capability, { name: 'edit',   category: pages_cc }
-seed Capability, { name: 'delete', category: pages_cc }
+seed Capability, { name: 'list',    category: pages_cc }
+seed Capability, { name: 'add',     category: pages_cc }
+seed Capability, { name: 'edit',    category: pages_cc }
+seed Capability, { name: 'destroy', category: pages_cc }
 # Page Sections
-seed Capability, { name: 'list',   category: sections_cc }
-seed Capability, { name: 'add',    category: sections_cc }
-seed Capability, { name: 'edit',   category: sections_cc }
-seed Capability, { name: 'delete', category: sections_cc }
+seed Capability, { name: 'list',    category: sections_cc }
+seed Capability, { name: 'add',     category: sections_cc }
+seed Capability, { name: 'edit',    category: sections_cc }
+seed Capability, { name: 'destroy', category: sections_cc }
 # Page Templates
-seed Capability, { name: 'list',   category: templates_cc }
-seed Capability, { name: 'add',    category: templates_cc }
-seed Capability, { name: 'edit',   category: templates_cc }
-seed Capability, { name: 'delete', category: templates_cc }
+seed Capability, { name: 'list',    category: templates_cc }
+seed Capability, { name: 'add',     category: templates_cc }
+seed Capability, { name: 'edit',    category: templates_cc }
+seed Capability, { name: 'destroy', category: templates_cc }
 # Shared Content
-seed Capability, { name: 'list',   category: shared_cc }
-seed Capability, { name: 'add',    category: shared_cc }
-seed Capability, { name: 'edit',   category: shared_cc }
-seed Capability, { name: 'delete', category: shared_cc }
+seed Capability, { name: 'list',    category: shared_cc }
+seed Capability, { name: 'add',     category: shared_cc }
+seed Capability, { name: 'edit',    category: shared_cc }
+seed Capability, { name: 'destroy', category: shared_cc }
 # Users
-seed Capability, { name: 'list',   category: users_cc }
-seed Capability, { name: 'add',    category: users_cc }
-seed Capability, { name: 'edit',   category: users_cc }
-seed Capability, { name: 'delete', category: users_cc }
+seed Capability, { name: 'list',    category: users_cc }
+seed Capability, { name: 'add',     category: users_cc }
+seed Capability, { name: 'edit',    category: users_cc }
+seed Capability, { name: 'destroy', category: users_cc }
 seed Capability, { name: 'view_admin_notes', category: users_cc }
 # Admin Users
-seed Capability, { name: 'list',   category: admins_cc }
-seed Capability, { name: 'add',    category: admins_cc }
-seed Capability, { name: 'edit',   category: admins_cc }
-seed Capability, { name: 'delete', category: admins_cc }
+seed Capability, { name: 'list',    category: admins_cc }
+seed Capability, { name: 'add',     category: admins_cc }
+seed Capability, { name: 'edit',    category: admins_cc }
+seed Capability, { name: 'destroy', category: admins_cc }
 
 # One Admin To Rule Them All
 admin = seed User, { username: 'admin' }, {

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -95,15 +95,15 @@ FactoryBot.define do
     after :create do |admin|
       category = create :capability_category, name: 'settings'
 
-      list   = create :capability, name: 'list',   category: category
-      add    = create :capability, name: 'add',    category: category
-      edit   = create :capability, name: 'edit',   category: category
-      delete = create :capability, name: 'delete', category: category
+      list    = create :capability, name: 'list',    category: category
+      add     = create :capability, name: 'add',     category: category
+      edit    = create :capability, name: 'edit',    category: category
+      destroy = create :capability, name: 'destroy', category: category
 
       create :user_capability, user: admin, capability: list
       create :user_capability, user: admin, capability: add
       create :user_capability, user: admin, capability: edit
-      create :user_capability, user: admin, capability: delete
+      create :user_capability, user: admin, capability: destroy
     end
   end
 
@@ -145,15 +145,15 @@ FactoryBot.define do
     after :create do |admin|
       category = create :capability_category, name: 'admin_users'
 
-      list   = create :capability, name: 'list',   category: category
-      add    = create :capability, name: 'add',    category: category
-      edit   = create :capability, name: 'edit',   category: category
-      delete = create :capability, name: 'delete', category: category
+      list    = create :capability, name: 'list',    category: category
+      add     = create :capability, name: 'add',     category: category
+      edit    = create :capability, name: 'edit',    category: category
+      destroy = create :capability, name: 'destroy', category: category
 
       create :user_capability, user: admin, capability: list
       create :user_capability, user: admin, capability: add
       create :user_capability, user: admin, capability: edit
-      create :user_capability, user: admin, capability: delete
+      create :user_capability, user: admin, capability: destroy
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -49,29 +49,29 @@ FactoryBot.define do
 
   factory :page_admin, parent: :admin_user do
     after :create do |admin|
-      pages_category = create :capability_category, name: 'pages'
+      category = create :capability_category, name: 'pages'
 
-      list   = create :capability, name: 'list',   category: pages_category
-      add    = create :capability, name: 'add',    category: pages_category
-      edit   = create :capability, name: 'edit',   category: pages_category
-      delete = create :capability, name: 'delete', category: pages_category
-
-      create :user_capability, user: admin, capability: list
-      create :user_capability, user: admin, capability: add
-      create :user_capability, user: admin, capability: edit
-      create :user_capability, user: admin, capability: delete
-
-      sections_category = create :capability_category, name: 'page_sections'
-
-      list   = create :capability, name: 'list',   category: sections_category
-      add    = create :capability, name: 'add',    category: sections_category
-      edit   = create :capability, name: 'edit',   category: sections_category
-      delete = create :capability, name: 'delete', category: sections_category
+      list    = create :capability, name: 'list',    category: category
+      add     = create :capability, name: 'add',     category: category
+      edit    = create :capability, name: 'edit',    category: category
+      destroy = create :capability, name: 'destroy', category: category
 
       create :user_capability, user: admin, capability: list
       create :user_capability, user: admin, capability: add
       create :user_capability, user: admin, capability: edit
-      create :user_capability, user: admin, capability: delete
+      create :user_capability, user: admin, capability: destroy
+
+      category = create :capability_category, name: 'page_sections'
+
+      list    = create :capability, name: 'list',    category: category
+      add     = create :capability, name: 'add',     category: category
+      edit    = create :capability, name: 'edit',    category: category
+      destroy = create :capability, name: 'destroy', category: category
+
+      create :user_capability, user: admin, capability: list
+      create :user_capability, user: admin, capability: add
+      create :user_capability, user: admin, capability: edit
+      create :user_capability, user: admin, capability: destroy
     end
   end
 
@@ -79,15 +79,15 @@ FactoryBot.define do
     after :create do |admin|
       category = create :capability_category, name: 'page_templates'
 
-      list   = create :capability, name: 'list',   category: category
-      add    = create :capability, name: 'add',    category: category
-      edit   = create :capability, name: 'edit',   category: category
-      delete = create :capability, name: 'delete', category: category
+      list    = create :capability, name: 'list',    category: category
+      add     = create :capability, name: 'add',     category: category
+      edit    = create :capability, name: 'edit',    category: category
+      destroy = create :capability, name: 'destroy', category: category
 
       create :user_capability, user: admin, capability: list
       create :user_capability, user: admin, capability: add
       create :user_capability, user: admin, capability: edit
-      create :user_capability, user: admin, capability: delete
+      create :user_capability, user: admin, capability: destroy
     end
   end
 
@@ -127,16 +127,16 @@ FactoryBot.define do
     after :create do |admin|
       category = create :capability_category, name: 'users'
 
-      list   = create :capability, name: 'list',   category: category
-      add    = create :capability, name: 'add',    category: category
-      edit   = create :capability, name: 'edit',   category: category
-      delete = create :capability, name: 'delete', category: category
-      notes  = create :capability, name: 'view_admin_notes', category: category
+      list    = create :capability, name: 'list',             category: category
+      add     = create :capability, name: 'add',              category: category
+      edit    = create :capability, name: 'edit',             category: category
+      destroy = create :capability, name: 'destroy',          category: category
+      notes   = create :capability, name: 'view_admin_notes', category: category
 
       create :user_capability, user: admin, capability: list
       create :user_capability, user: admin, capability: add
       create :user_capability, user: admin, capability: edit
-      create :user_capability, user: admin, capability: delete
+      create :user_capability, user: admin, capability: destroy
       create :user_capability, user: admin, capability: notes
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -111,15 +111,15 @@ FactoryBot.define do
     after :create do |admin|
       category = create :capability_category, name: 'shared_content'
 
-      list   = create :capability, name: 'list',   category: category
-      add    = create :capability, name: 'add',    category: category
-      edit   = create :capability, name: 'edit',   category: category
-      delete = create :capability, name: 'delete', category: category
+      list    = create :capability, name: 'list',    category: category
+      add     = create :capability, name: 'add',     category: category
+      edit    = create :capability, name: 'edit',    category: category
+      destroy = create :capability, name: 'destroy', category: category
 
       create :user_capability, user: admin, capability: list
       create :user_capability, user: admin, capability: add
       create :user_capability, user: admin, capability: edit
-      create :user_capability, user: admin, capability: delete
+      create :user_capability, user: admin, capability: destroy
     end
   end
 

--- a/spec/requests/admin/blog/posts_spec.rb
+++ b/spec/requests/admin/blog/posts_spec.rb
@@ -8,27 +8,26 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
     sign_in @admin
   end
 
-  describe 'GET /admin/blog/posts' do
+  describe 'GET /admin/blog/1/posts' do
     it 'fetches the list of blog posts' do
-      get admin_blog_posts_path
+      get blog_posts_path( @blog )
 
       expect( response ).to have_http_status :ok
     end
   end
 
-  describe 'GET /admin/blog/posts/new' do
+  describe 'GET /admin/blog/1/posts/new' do
     it 'loads the form to create a new blog post' do
-      get new_admin_blog_post_path
+      get new_blog_post_path( @blog )
 
       expect( response ).to have_http_status :ok
     end
   end
 
-  describe 'POST /admin/blog/posts' do
+  describe 'POST /admin/blog/1/post' do
     it 'fails to create a new blog post when an incomplete form is submitted' do
-      post admin_blog_posts_path, params: {
+      post create_blog_post_path( @blog ), params: {
         blog_post: {
-          blog_id: @blog.id,
           user_id: @admin.id,
           title: Faker::Science.unique.scientist,
           body: nil
@@ -41,9 +40,8 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
     end
 
     it 'creates a new blog post when a complete form is submitted' do
-      post admin_blog_posts_path, params: {
+      post create_blog_post_path( @blog ), params: {
         blog_post: {
-          blog_id: @blog.id,
           user_id: @admin.id,
           title: Faker::Science.unique.scientist,
           body: Faker::Lorem.paragraph
@@ -53,7 +51,7 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
       post = BlogPost.last
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to edit_admin_blog_post_path( post )
+      expect( response      ).to redirect_to edit_blog_post_path( @blog, post )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.blog.posts.edit.title' ).titlecase
@@ -61,23 +59,22 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
     end
   end
 
-  describe 'GET /admin/blog/posts/:id/edit' do
+  describe 'GET /admin/blog/1/posts/:id/edit' do
     it 'loads the form to edit an existing blog post' do
       post = create :blog_post, blog: @blog
 
-      get edit_admin_blog_post_path( post )
+      get edit_blog_post_path( @blog, post )
 
       expect( response ).to have_http_status :ok
     end
   end
 
-  describe 'POST /admin/blog/posts' do
+  describe 'POST /admin/blog/1/posts' do
     it 'fails to update the blog post when an incomplete form is submitted' do
       post = create :blog_post, blog: @blog
 
-      put admin_blog_post_path( post ), params: {
+      put blog_post_path( @blog, post ), params: {
         blog_post: {
-          blog_id: @blog.id,
           user_id: @admin.id,
           title: Faker::Science.unique.scientist,
           body: nil
@@ -92,9 +89,8 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
     it 'updates the blog post when a complete form is submitted' do
       post = create :blog_post, blog: @blog
 
-      put admin_blog_post_path( post ), params: {
+      put blog_post_path( @blog, post ), params: {
         blog_post: {
-          blog_id: @blog.id,
           user_id: @admin.id,
           title: Faker::Science.unique.scientist,
           body: Faker::Lorem.paragraph
@@ -104,7 +100,7 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
       post = BlogPost.last
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to edit_admin_blog_post_path( post )
+      expect( response      ).to redirect_to edit_blog_post_path( @blog, post )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.blog.posts.edit.title' ).titlecase
@@ -112,16 +108,16 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
     end
   end
 
-  describe 'DELETE /admin/blog/posts/:id' do
+  describe 'DELETE /admin/blog/1/posts/:id' do
     it 'deletes the specified blog post' do
       p1 = create :blog_post, blog: @blog
       p2 = create :blog_post, blog: @blog
       p3 = create :blog_post, blog: @blog
 
-      delete admin_blog_post_path( p2 )
+      delete blog_post_path( @blog, p2 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_blog_posts_path
+      expect( response      ).to     redirect_to blog_posts_path( @blog )
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.blog.posts.index.title' ).titlecase
@@ -132,10 +128,10 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
     end
 
     it 'fails gracefully when attempting to delete a non-existent blog post' do
-      delete admin_blog_post_path( 999 )
+      delete blog_post_path( @blog, 999 )
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_blog_posts_path
+      expect( response      ).to redirect_to blog_posts_path( @blog )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.blog.posts.index.title' ).titlecase

--- a/spec/requests/admin/blogs_spec.rb
+++ b/spec/requests/admin/blogs_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
 
   describe 'GET /admin/blogs' do
     it 'fetches the list of blogs' do
-      get admin_blogs_path
+      get blogs_path
 
       expect( response ).to have_http_status :ok
     end
@@ -16,7 +16,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
 
   describe 'GET /admin/blogs/new' do
     it 'loads the form to create a new blog' do
-      get new_admin_blog_path
+      get new_blog_path
 
       expect( response ).to have_http_status :ok
     end
@@ -24,7 +24,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
 
   describe 'POST /admin/blogs' do
     it 'fails to create a new blog when an incomplete form is submitted' do
-      post admin_blogs_path, params: {
+      post create_blog_path, params: {
         blog: {
           user_id: @admin.id,
           name: nil
@@ -37,7 +37,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
     end
 
     it 'creates a new blog when a complete form is submitted' do
-      post admin_blogs_path, params: {
+      post create_blog_path, params: {
         blog: {
           user_id: @admin.id,
           name: Faker::Science.unique.scientist
@@ -47,7 +47,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
       blog = Blog.last
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to edit_admin_blog_path( blog )
+      expect( response      ).to redirect_to edit_blog_path( blog )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.blogs.edit.title' ).titlecase
@@ -59,7 +59,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
     it 'loads the form to edit an existing blog' do
       blog = create :blog
 
-      get edit_admin_blog_path( blog )
+      get edit_blog_path( blog )
 
       expect( response ).to have_http_status :ok
     end
@@ -69,7 +69,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
     it 'fails to update the blog details when an incomplete form is submitted' do
       blog = create :blog
 
-      put admin_blog_path( blog ), params: {
+      put blog_path( blog ), params: {
         blog: {
           user_id: @admin.id,
           name: nil
@@ -84,7 +84,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
     it 'updates the blog details when a complete form is submitted' do
       blog = create :blog
 
-      put admin_blog_path( blog ), params: {
+      put blog_path( blog ), params: {
         blog: {
           user_id: @admin.id,
           name: Faker::Science.unique.scientist
@@ -94,7 +94,7 @@ RSpec.describe 'Admin::Blogs', type: :request do
       blog = Blog.last
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to edit_admin_blog_path( blog )
+      expect( response      ).to redirect_to edit_blog_path( blog )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.blogs.edit.title' ).titlecase
@@ -108,10 +108,10 @@ RSpec.describe 'Admin::Blogs', type: :request do
       b2 = create :blog
       b3 = create :blog
 
-      delete admin_blog_path( b2 )
+      delete blog_path( b2 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_blogs_path
+      expect( response      ).to     redirect_to blogs_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.blogs.index.title' ).titlecase
@@ -122,10 +122,10 @@ RSpec.describe 'Admin::Blogs', type: :request do
     end
 
     it 'fails gracefully when attempting to delete a non-existent blog' do
-      delete admin_blog_path( 999 )
+      delete blog_path( 999 )
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_blogs_path
+      expect( response      ).to redirect_to blogs_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.blogs.index.title' ).titlecase

--- a/spec/requests/admin/pages/sections_spec.rb
+++ b/spec/requests/admin/pages/sections_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe 'Admin: Page Sections', type: :request do
 
   describe 'GET /admin/pages/sections' do
     it 'redirects to the combined pages+sections list' do
-      get admin_pages_sections_path
+      get page_sections_path
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_pages_path
+      expect( response      ).to redirect_to pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
@@ -20,7 +20,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
 
   describe 'GET /admin/pages/section/new' do
     it 'loads the form to add a new section' do
-      get admin_pages_section_new_path
+      get new_page_section_path
 
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.sections.new.title' ).titlecase
@@ -29,7 +29,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
 
   describe 'POST /admin/pages/section/new' do
     it 'fails when the form is submitted without all the details' do
-      post admin_pages_section_new_path, params: {
+      post create_page_section_path, params: {
         'page_section[title]': 'Test'
       }
 
@@ -39,7 +39,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
     end
 
     it 'fails if top-level section slug collides with a controller namespace' do
-      post admin_pages_section_new_path, params: {
+      post create_page_section_path, params: {
         'page_section[name]': 'Test',
         'page_section[title]': 'Test',
         'page_section[slug]': 'user'
@@ -51,14 +51,14 @@ RSpec.describe 'Admin: Page Sections', type: :request do
     end
 
     it 'adds a new section when the form is submitted' do
-      post admin_pages_section_new_path, params: {
+      post create_page_section_path, params: {
         'page_section[name]': 'Test',
         'page_section[title]': 'Test',
         'page_section[slug]': 'test'
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_pages_section_path( PageSection.last )
+      expect( response      ).to redirect_to edit_page_section_path( PageSection.last )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.title' ).titlecase
@@ -70,7 +70,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
     it 'loads the form to edit an existing section' do
       section = create :page_section
 
-      get admin_pages_section_path( section )
+      get edit_page_section_path( section )
 
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.title' ).titlecase
@@ -81,7 +81,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
     it 'fails to update the section when submitted without all the details' do
       section = create :page_section
 
-      post admin_pages_section_path( section ), params: {
+      put page_section_path( section ), params: {
         'page_section[name]': nil
       }
 
@@ -93,12 +93,12 @@ RSpec.describe 'Admin: Page Sections', type: :request do
     it 'updates the section when the form is submitted' do
       section = create :page_section
 
-      post admin_pages_section_path( section ), params: {
+      put page_section_path( section ), params: {
         'page_section[name]': 'Updated by test'
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_pages_section_path( section )
+      expect( response      ).to redirect_to edit_page_section_path( section )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.sections.edit.title' ).titlecase
@@ -113,28 +113,28 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       s2 = create :page_section
       s3 = create :page_section
 
-      delete admin_pages_section_delete_path( s2 )
+      delete page_section_path( s2 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_pages_path
+      expect( response      ).to     redirect_to pages_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.pages.index.title' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.sections.delete.success' )
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.sections.destroy.success' )
       expect( response.body ).to     include s1.name
       expect( response.body ).not_to include s2.name
       expect( response.body ).to     include s3.name
     end
 
     it 'fails gracefully when attempting to delete a non-existent section' do
-      delete admin_pages_section_delete_path( 999 )
+      delete page_section_path( 999 )
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_pages_path
+      expect( response      ).to redirect_to pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.delete.failure' )
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.sections.destroy.failure' )
     end
   end
 end

--- a/spec/requests/admin/pages/templates_spec.rb
+++ b/spec/requests/admin/pages/templates_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
     it 'fetches the list of templates in the admin area' do
       template = create :page_template
 
-      get admin_pages_templates_path
+      get page_templates_path
 
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.templates.index.title' ).titlecase
@@ -20,7 +20,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
 
   describe 'GET /admin/pages/template/new' do
     it 'loads the form to add a new template' do
-      get admin_pages_template_new_path
+      get new_page_template_path
 
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.templates.new.title' ).titlecase
@@ -29,7 +29,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
 
   describe 'POST /admin/pages/template/new' do
     it 'fails when the form is submitted without all the details' do
-      post admin_pages_template_new_path, params: {
+      post create_page_template_path, params: {
         'page_template[filename]': 'Test'
       }
 
@@ -39,7 +39,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
     end
 
     it 'adds a new template when the form is submitted' do
-      post admin_pages_template_new_path, params: {
+      post create_page_template_path, params: {
         'page_template[name]': 'Test',
         'page_template[filename]': 'an_example'
       }
@@ -52,7 +52,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
     end
 
     it 'adds the right number of elements to the new template' do
-      post admin_pages_template_new_path, params: {
+      post create_page_template_path, params: {
         'page_template[name]': 'Another Test',
         'page_template[filename]': 'an_example'
       }
@@ -70,7 +70,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
     it 'loads the form to edit an existing template' do
       template = create :page_template
 
-      get admin_pages_template_path( template )
+      get edit_page_template_path( template )
 
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.templates.edit.title' ).titlecase
@@ -81,7 +81,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
     it 'fails to update the template when submitted without all the details' do
       template = create :page_template
 
-      post admin_pages_template_path( template ), params: {
+      put page_template_path( template ), params: {
         'page_template[name]': nil
       }
 
@@ -94,7 +94,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       template = create :page_template
       e_id = PageTemplateElement.last.id
 
-      post admin_pages_template_path( template ), params: {
+      put page_template_path( template ), params: {
         'page_template[name]': 'Updated by test',
         "elements[element_#{e_id}_name]": 'updated_element_name',
         "elements[element_#{e_id}_content]": 'Default content',
@@ -116,27 +116,27 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       t2 = create :page_template
       create :page_template
 
-      delete admin_pages_template_delete_path( t2 )
+      delete page_template_path( t2 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_pages_templates_path
+      expect( response      ).to     redirect_to page_templates_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.pages.templates.index.title' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.templates.delete.success' )
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.templates.destroy.success' )
       expect( response.body ).to     include t1.name
       expect( response.body ).not_to include t2.name
     end
 
     it 'fails gracefully when attempting to delete a non-existent template' do
-      delete admin_pages_template_delete_path( 999 )
+      delete page_template_path( 999 )
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_pages_templates_path
+      expect( response      ).to redirect_to page_templates_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.templates.index.title' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.templates.delete.failure' )
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.templates.destroy.failure' )
     end
   end
 end

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Admin: Pages', type: :request do
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_page_path( Page.last )
+      expect( response      ).to redirect_to edit_page_path( Page.last )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
@@ -92,7 +92,7 @@ RSpec.describe 'Admin: Pages', type: :request do
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_page_path( Page.last )
+      expect( response      ).to redirect_to edit_page_path( Page.last )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
@@ -134,7 +134,7 @@ RSpec.describe 'Admin: Pages', type: :request do
     it 'fails to update the page when submitted with a blank name' do
       page = create :page
 
-      post page_path( page ), params: {
+      put page_path( page ), params: {
         'page[name]': ''
       }
 
@@ -146,12 +146,12 @@ RSpec.describe 'Admin: Pages', type: :request do
     it 'updates the page when the form is submitted' do
       page = create :page
 
-      post page_path( page ), params: {
+      put page_path( page ), params: {
         'page[name]': 'Updated by test'
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_page_path( page )
+      expect( response      ).to redirect_to edit_page_path( page )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.edit.title' ).titlecase
@@ -163,13 +163,13 @@ RSpec.describe 'Admin: Pages', type: :request do
       page = create :page
       old_slug = page.slug
 
-      post page_path( page ), params: {
+      put page_path( page ), params: {
         'page[name]': 'Updated by test',
         'page[slug]': ''
       }
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_page_path( page )
+      expect( response      ).to     redirect_to edit_page_path( page )
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.pages.edit.title' ).titlecase
@@ -188,11 +188,11 @@ RSpec.describe 'Admin: Pages', type: :request do
       delete page_path( p2 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_pages_path
+      expect( response      ).to     redirect_to pages_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.pages.index.title' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.delete.success' )
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.destroy.success' )
       expect( response.body ).to     include p1.name
       expect( response.body ).not_to include p2.name
       expect( response.body ).to     include p3.name
@@ -202,11 +202,11 @@ RSpec.describe 'Admin: Pages', type: :request do
       delete page_path( 999 )
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_pages_path
+      expect( response      ).to redirect_to pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.delete.failure' )
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.pages.destroy.failure' )
     end
   end
 end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -8,22 +8,22 @@ RSpec.describe 'Admin: Site Settings', type: :request do
 
   describe 'GET /admin/settings' do
     it 'fetches the site settings page in the admin area' do
-      get admin_settings_path
+      get settings_path
 
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
     end
   end
 
-  describe 'POST /admin/settings/create' do
+  describe 'POST /admin/setting' do
     it 'adds a new setting, with a string value' do
-      post admin_setting_create_path, params: {
+      post setting_path, params: {
         'setting[name]': 'New Setting Is New',
         'setting[value]': 'AND IMPROVED!'
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_settings_path
+      expect( response      ).to redirect_to settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
@@ -32,13 +32,13 @@ RSpec.describe 'Admin: Site Settings', type: :request do
     end
 
     it 'adds a new setting, with an empty string value' do
-      post admin_setting_create_path, params: {
+      post setting_path, params: {
         'setting[name]': 'New Setting Is Empty',
         'setting[value]': ''
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_settings_path
+      expect( response      ).to redirect_to settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
@@ -47,13 +47,13 @@ RSpec.describe 'Admin: Site Settings', type: :request do
     end
 
     it 'adds a new setting, with an explicitly null value' do
-      post admin_setting_create_path, params: {
+      post setting_path, params: {
         'setting[name]': 'New Setting Is Null',
         'setting[value]': nil
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_settings_path
+      expect( response      ).to redirect_to settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
@@ -62,12 +62,12 @@ RSpec.describe 'Admin: Site Settings', type: :request do
     end
 
     it 'attempting to add a new setting with no name fails gracefully' do
-      post admin_setting_create_path, params: {
+      post setting_path, params: {
         'setting[value]': 'MADE OF FAIL!'
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_settings_path
+      expect( response      ).to redirect_to settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
@@ -81,28 +81,28 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       s2 = create :setting, name: 'DO NOT WANT'
       s3 = create :setting
 
-      delete admin_setting_delete_path( s2 )
+      delete delete_setting_path( s2 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_settings_path
+      expect( response      ).to     redirect_to settings_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.settings.index.title' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.settings.delete.success' )
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.settings.destroy.success' )
       expect( response.body ).to     include s1.name
       expect( response.body ).to     include s3.name
       expect( response.body ).not_to include s2.name
     end
 
     it 'fails gracefully when attempting to delete a non-existent setting' do
-      delete admin_setting_delete_path( 999 )
+      delete delete_setting_path( 999 )
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_settings_path
+      expect( response      ).to redirect_to settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.settings.delete.failure' )
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.settings.destroy.failure' )
     end
   end
 
@@ -112,12 +112,12 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       s2 = create :setting, value: 'Original value'
       create :setting
 
-      post admin_settings_path, params: {
+      put settings_path, params: {
         "settings[setting_value_#{s2.id}]": 'Updated value'
       }
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_settings_path
+      expect( response      ).to     redirect_to settings_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.settings.index.title' ).titlecase
@@ -131,12 +131,12 @@ RSpec.describe 'Admin: Site Settings', type: :request do
       s2 = create :setting
       create :setting
 
-      post admin_settings_path, params: {
+      put settings_path, params: {
         "settings[setting_value_#{s2.id}]": s2.value
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_settings_path
+      expect( response      ).to redirect_to settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase

--- a/spec/requests/admin/shared_content_spec.rb
+++ b/spec/requests/admin/shared_content_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Admin: Shared Content', type: :request do
 
   describe 'GET /admin/shared-content' do
     it 'fetches the shared content page in the admin area' do
-      get admin_shared_content_path
+      get shared_content_path
 
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
@@ -17,14 +17,14 @@ RSpec.describe 'Admin: Shared Content', type: :request do
 
   describe 'POST /admin/shared-content/create' do
     it 'adds a new Short Text element' do
-      post admin_shared_content_create_path, params: {
+      post shared_content_path, params: {
         'shared_content_element[name]': 'new_shared_content',
         'shared_content_element[content]': 'NEW AND IMPROVED!',
         'shared_content_element[content_type]': I18n.t( 'admin.elements.short_text' )
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_shared_content_path
+      expect( response      ).to redirect_to shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
@@ -33,14 +33,14 @@ RSpec.describe 'Admin: Shared Content', type: :request do
     end
 
     it 'adds a new element, with an empty content string' do
-      post admin_shared_content_create_path, params: {
+      post shared_content_path, params: {
         'shared_content_element[name]': 'shared_content_is_empty',
         'shared_content_element[content]': '',
         'shared_content_element[content_type]': I18n.t( 'admin.elements.short_text' )
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_shared_content_path
+      expect( response      ).to redirect_to shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
@@ -49,14 +49,14 @@ RSpec.describe 'Admin: Shared Content', type: :request do
     end
 
     it 'adds a new element, with a NULL content string' do
-      post admin_shared_content_create_path, params: {
+      post shared_content_path, params: {
         'shared_content_element[name]': 'shared_content_is_null',
         'shared_content_element[content]': nil,
         'shared_content_element[content_type]': I18n.t( 'admin.elements.short_text' )
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_shared_content_path
+      expect( response      ).to redirect_to shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
@@ -65,12 +65,12 @@ RSpec.describe 'Admin: Shared Content', type: :request do
     end
 
     it 'attempting to add a new shared_content element with no name fails gracefully' do
-      post admin_shared_content_create_path, params: {
+      post shared_content_path, params: {
         'shared_content_element[content]': 'MADE OF FAIL!'
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_shared_content_path
+      expect( response      ).to redirect_to shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
@@ -84,28 +84,28 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       s2 = create :shared_content_element, name: 'do_not_want'
       s3 = create :shared_content_element
 
-      delete admin_shared_content_delete_path( s2 )
+      delete delete_shared_content_path( s2 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_shared_content_path
+      expect( response      ).to     redirect_to shared_content_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.shared_content.delete.success' )
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.shared_content.destroy.success' )
       expect( response.body ).to     include s1.name
       expect( response.body ).to     include s3.name
       expect( response.body ).not_to include 'do_not_want'
     end
 
     it 'fails gracefully when attempting to delete non-existent shared content' do
-      delete admin_shared_content_delete_path( 999 )
+      delete delete_shared_content_path( 999 )
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_shared_content_path
+      expect( response      ).to redirect_to shared_content_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
-      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.shared_content.delete.failure' )
+      expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.shared_content.destroy.failure' )
     end
   end
 
@@ -115,14 +115,14 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       s2 = create :shared_content_element, content: 'Original content'
       create :shared_content_element
 
-      post admin_shared_content_path, params: {
+      put shared_content_path, params: {
         "shared_content[elements_attributes][1][id]": s2.id,
         "shared_content[elements_attributes][1][content]": 'Updated content',
         "shared_content[elements_attributes][1][content_type]": 'Short Text'
       }
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_shared_content_path
+      expect( response      ).to     redirect_to shared_content_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.title' ).titlecase
@@ -135,7 +135,7 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       s1 = create :shared_content_element, content: 'Original content'
       s2 = create :shared_content_element
 
-      post admin_shared_content_path, params: {
+      put shared_content_path, params: {
         "shared_content[elements_attributes][1][id]": s1.id,
         "shared_content[elements_attributes][1][name]": s2.name,
         "shared_content[elements_attributes][1][content]": 'Updated content',
@@ -143,7 +143,7 @@ RSpec.describe 'Admin: Shared Content', type: :request do
       }
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to admin_shared_content_path
+      expect( response      ).to     redirect_to shared_content_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.shared_content.index.title' ).titlecase

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Admin: Users', type: :request do
       it 'fetches the list of users in the admin area' do
         user = create :user
 
-        get admin_users_path
+        get users_path
 
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title I18n.t( 'admin.users.index.title' ).titlecase
@@ -21,7 +21,7 @@ RSpec.describe 'Admin: Users', type: :request do
 
     describe 'GET /admin/user/new' do
       it 'loads the form to add a new user' do
-        get admin_user_new_path
+        get new_user_path
 
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title I18n.t( 'admin.users.new.title' ).titlecase
@@ -30,7 +30,7 @@ RSpec.describe 'Admin: Users', type: :request do
 
     describe 'POST /admin/user/new' do
       it 'fails when the form is submitted without all the details' do
-        post admin_user_new_path, params: {
+        post create_user_path, params: {
           'user[username]': Faker::Internet.unique.username
         }
 
@@ -42,7 +42,7 @@ RSpec.describe 'Admin: Users', type: :request do
       it 'fails when the username collides with an existing username' do
         create :user, username: 'test'
 
-        post admin_user_new_path, params: {
+        post create_user_path, params: {
           'user[username]': 'test',
           'user[password]': Faker::Internet.unique.password,
           'user[email]': Faker::Internet.unique.email
@@ -54,14 +54,14 @@ RSpec.describe 'Admin: Users', type: :request do
       end
 
       it 'adds a new user when the form is submitted' do
-        post admin_user_new_path, params: {
+        post create_user_path, params: {
           'user[username]': Faker::Internet.unique.username,
           'user[password]': Faker::Internet.unique.password,
           'user[email]': Faker::Internet.unique.email
         }
 
         expect( response      ).to have_http_status :found
-        expect( response      ).to redirect_to admin_user_path( User.last )
+        expect( response      ).to redirect_to edit_user_path( User.last )
         follow_redirect!
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase
@@ -73,7 +73,7 @@ RSpec.describe 'Admin: Users', type: :request do
       it 'loads the form to edit an existing user, without the section for editing abilities' do
         user = create :user
 
-        get admin_user_path( user )
+        get edit_user_path( user )
 
         expect( response      ).to     have_http_status :ok
         expect( response.body ).to     have_title I18n.t( 'admin.users.edit.title' ).titlecase
@@ -85,7 +85,7 @@ RSpec.describe 'Admin: Users', type: :request do
       it 'fails to update the user when submitted with a blank username' do
         user = create :user
 
-        post admin_user_path( user ), params: {
+        put user_path( user ), params: {
           'user[username]': ''
         }
 
@@ -97,12 +97,12 @@ RSpec.describe 'Admin: Users', type: :request do
       it 'updates the user when the form is submitted' do
         user = create :user
 
-        post admin_user_path( user ), params: {
+        put user_path( user ), params: {
           'user[username]': 'new_username'
         }
 
         expect( response      ).to have_http_status :found
-        expect( response      ).to redirect_to admin_user_path( user )
+        expect( response      ).to redirect_to edit_user_path( user )
         follow_redirect!
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase
@@ -117,28 +117,28 @@ RSpec.describe 'Admin: Users', type: :request do
         u2 = create :user
         u3 = create :user
 
-        delete admin_user_delete_path( u2 )
+        delete user_path( u2 )
 
         expect( response      ).to     have_http_status :found
-        expect( response      ).to     redirect_to admin_users_path
+        expect( response      ).to     redirect_to users_path
         follow_redirect!
         expect( response      ).to     have_http_status :ok
         expect( response.body ).to     have_title I18n.t( 'admin.users.index.title' ).titlecase
-        expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.users.delete.success' )
+        expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.users.destroy.success' )
         expect( response.body ).to     include u1.username
         expect( response.body ).not_to include u2.username
         expect( response.body ).to     include u3.username
       end
 
       it 'fails gracefully when attempting to delete a non-existent user' do
-        delete admin_user_delete_path( 999 )
+        delete user_path( 999 )
 
         expect( response      ).to have_http_status :found
-        expect( response      ).to redirect_to admin_users_path
+        expect( response      ).to redirect_to users_path
         follow_redirect!
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title I18n.t( 'admin.users.index.title' ).titlecase
-        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.delete.failure' )
+        expect( response.body ).to have_css '.alert-danger', text: I18n.t( 'admin.users.destroy.failure' )
       end
     end
   end
@@ -153,7 +153,7 @@ RSpec.describe 'Admin: Users', type: :request do
       it "includes section for editing user's admin capabilities" do
         user = create :user
 
-        get admin_user_path( user )
+        get edit_user_path( user )
 
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase
@@ -169,12 +169,12 @@ RSpec.describe 'Admin: Users', type: :request do
 
       expect( user.capabilities.length ).to eq 0
 
-      post admin_user_path( user ), params: {
+      put user_path( user ), params: {
         "#{field_name}": 'on'
       }
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_user_path( user )
+      expect( response      ).to redirect_to edit_user_path( user )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.users.edit.title' ).titlecase

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Admin', type: :request do
       get admin_path
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_pages_path
+      expect( response      ).to redirect_to pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
@@ -45,7 +45,7 @@ RSpec.describe 'Admin', type: :request do
       get admin_path
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_blogs_path
+      expect( response      ).to redirect_to blogs_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.blogs.index.title' ).titlecase
@@ -58,7 +58,7 @@ RSpec.describe 'Admin', type: :request do
       get admin_path
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_pages_path
+      expect( response      ).to redirect_to pages_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
@@ -71,7 +71,7 @@ RSpec.describe 'Admin', type: :request do
       get admin_path
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_settings_path
+      expect( response      ).to redirect_to settings_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.settings.index.title' ).titlecase
@@ -84,7 +84,7 @@ RSpec.describe 'Admin', type: :request do
       get admin_path
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to admin_users_path
+      expect( response      ).to redirect_to users_path
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.users.index.title' ).titlecase

--- a/spec/requests/blogs_spec.rb
+++ b/spec/requests/blogs_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Blogs', type: :request do
 
   describe 'GET #recent' do
     it 'returns a success response' do
-      get blog_path
+      get view_blog_path
 
       expect( response ).to have_http_status :ok
 
@@ -20,7 +20,7 @@ RSpec.describe 'Blogs', type: :request do
       create :page
       Blog.all.destroy_all
 
-      get blog_path
+      get view_blog_path
 
       expect( response ).to have_http_status :found
       expect( response ).to redirect_to root_path
@@ -36,6 +36,7 @@ RSpec.describe 'Blogs', type: :request do
     it 'returns a success response' do
       post = create :blog_post, blog: @blog
 
+      # get view_blog_post_path( post )
       get "/blog/#{post.posted_at.year}/#{post.posted_at.month}/#{post.slug}"
 
       expect( response ).to have_http_status :ok

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -39,37 +39,8 @@ RSpec.describe 'Pages', type: :request do
       end
     end
 
-    describe 'GET /pages' do
-      it 'fetches the default page' do
-        get '/pages'
-
-        expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title @page.title
-      end
-    end
-
-    describe 'GET /pages/page-name' do
-      it 'fetches the specified top-level page' do
-        get "/pages/#{@page.slug}"
-
-        expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title @page.title
-      end
-    end
-
-    describe 'GET /pages/section-name/page-name' do
-      it 'fetches the specified page from the specified section' do
-        page = create :page_in_section
-
-        get "/pages/#{page.section.slug}/#{page.slug}"
-
-        expect( response      ).to have_http_status :ok
-        expect( response.body ).to have_title page.title
-      end
-    end
-
     describe 'GET /page-name' do
-      it 'fetches the specified top-level page without /pages in the path' do
+      it 'fetches the specified top-level page' do
         get "/#{@page.slug}"
 
         expect( response      ).to have_http_status :ok
@@ -78,7 +49,7 @@ RSpec.describe 'Pages', type: :request do
     end
 
     describe 'GET /section-name/page-name' do
-      it 'fetches a page in a section without /pages in the path' do
+      it 'fetches the specified page from the specified section' do
         page = create :page_in_section
 
         get "/#{page.section.slug}/#{page.slug}"
@@ -88,14 +59,14 @@ RSpec.describe 'Pages', type: :request do
       end
     end
 
-    describe 'GET /pages/section-name' do
+    describe 'GET /section-name' do
       it 'fetches the first page from the specified section' do
         section = create :page_section
         create :page_in_section, title: '1st Page', section: section
         create :page_in_section, title: '2nd Page', section: section
         create :page_in_section, title: '3rd Page', section: section
 
-        get "/pages/#{section.slug}"
+        get "/#{section.slug}"
 
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title '1st Page'
@@ -108,38 +79,38 @@ RSpec.describe 'Pages', type: :request do
         page003 = create :page_in_section, title: '3rd Page', section: section
         page001.section.update! default_page_id: page003.id
 
-        get "/pages/#{page002.section.slug}"
+        get "/#{page002.section.slug}"
 
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title '3rd Page'
       end
     end
 
-    describe 'GET /pages/section-name/subsection-name/page-name' do
+    describe 'GET /section-name/subsection-name/page-name' do
       it 'fetches the specified page from the specified subsection' do
         p = create :page_in_subsection
 
-        get "/pages/#{p.section.section.slug}/#{p.section.slug}/#{p.slug}"
+        get "/#{p.section.section.slug}/#{p.section.slug}/#{p.slug}"
 
         expect( response      ).to have_http_status :ok
         expect( response.body ).to have_title p.title
       end
     end
 
-    describe 'GET /pages/non-existent-slug' do
+    describe 'GET /non-existent-slug' do
       it 'returns a 404 if no matching page or section is found at top-level' do
-        get '/pages/non-existent-slug'
+        get '/non-existent-slug'
 
         expect( response      ).to have_http_status :not_found
         expect( response.body ).to include 'a page that does not exist'
       end
     end
 
-    describe 'GET /pages/existing-section/non-existent-slug' do
+    describe 'GET /existing-section/non-existent-slug' do
       it 'returns a 404 if no matching page or sub-section is found in section' do
         page = create :page_in_section
 
-        get "/pages/#{page.section.slug}/non-existent-slug"
+        get "/#{page.section.slug}/non-existent-slug"
 
         expect( response      ).to have_http_status :not_found
         expect( response.body ).to include 'a page that does not exist'


### PR DESCRIPTION
Alter routing config to use the built-in Rails resource method (albeit with a lot of special casing, to get rid of the inappropriate and wildly irritating (yes I know it's just me) pluralisation in paths for singular entities).