### PR TITLE
CultureSeries.culture_ship <3

### DIFF
--- a/spec/factories/blog_posts.rb
+++ b/spec/factories/blog_posts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :blog_post, class: 'BlogPost' do
-    title  { Faker::Science.unique.scientist.titlecase }
+    title  { Faker::Books::CultureSeries.unique.culture_ship.titlecase }
     slug   { title.dup.parameterize }
     body   { Faker::Lorem.paragraph }
     hidden { false }

--- a/spec/factories/blogs.rb
+++ b/spec/factories/blogs.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :blog do
-    name   { Faker::Science.unique.scientist }
-    title  { name.dup.titlecase }
-    slug   { name.dup.parameterize }
+    name  { Faker::Books::CultureSeries.unique.culture_ship }
+    title { name.dup.titlecase    }
+    slug  { name.dup.parameterize }
 
     hidden_from_menu { false }
     hidden { false }

--- a/spec/factories/capabilities.rb
+++ b/spec/factories/capabilities.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :capability do
-    name { "#{Faker::Science.unique.element}_#{Faker::Science.unique.element}".downcase }
+    name { Faker::Books::CultureSeries.unique.civs.parameterize }
 
     association :category, factory: :capability_category
   end

--- a/spec/factories/capability_categories.rb
+++ b/spec/factories/capability_categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :capability_category do
-    name { "#{Faker::Science.unique.element}_#{Faker::Science.unique.element}".downcase }
+    name { Faker::Books::CultureSeries.unique.civs.parameterize }
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :comment do
     sequence( :number )
-    title   { Faker::Science.unique.scientist }
+    title   { Faker::Books::CultureSeries.unique.culture_ship.titlecase }
     body    { Faker::Lorem.paragraph }
     hidden  { false }
     author_type { 'anonymous' }

--- a/spec/factories/feature_flags.rb
+++ b/spec/factories/feature_flags.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :feature_flag do
-    name { "#{Faker::Science.unique.element}_#{Faker::Science.unique.element}".downcase }
+    name { Faker::Books::CultureSeries.unique.civs.parameterize }
   end
 end

--- a/spec/factories/insert_elements.rb
+++ b/spec/factories/insert_elements.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :insert_element do
-    name    { "#{Faker::Science.unique.element}_#{Faker::Science.unique.element}".downcase }
-    content { Faker::Science.unique.scientist }
+    name { Faker::Books::CultureSeries.unique.civs.parameterize }
     content_type { I18n.t( 'admin.elements.short_text' ) }
   end
 end

--- a/spec/factories/news_posts.rb
+++ b/spec/factories/news_posts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :news_post, class: 'NewsPost' do
-    title  { Faker::Science.unique.scientist.titlecase }
+    title  { Faker::Books::CultureSeries.unique.culture_ship.titlecase }
     slug   { title.dup.parameterize }
     body   { Faker::Lorem.paragraph }
     hidden { false }

--- a/spec/factories/page_elements.rb
+++ b/spec/factories/page_elements.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page_element do
-    name { "#{Faker::Science.unique.element}_#{Faker::Science.unique.element}".downcase }
+    name { Faker::Books::CultureSeries.unique.civs.parameterize }
   end
 
   factory :short_text_page_element, parent: :page_element do

--- a/spec/factories/page_sections.rb
+++ b/spec/factories/page_sections.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :page_section, aliases: [ :top_level_section ] do
-    name   { Faker::Science.unique.scientist }
-    title  { name.dup.titlecase }
-    slug   { name.dup.downcase.gsub( /[^\w\s]/, '' ).gsub( /\s+/, '-' ) }
+    name   { Faker::Books::CultureSeries.unique.culture_ship }
+    title  { name.dup.titlecase    }
+    slug   { name.dup.parameterize }
     hidden { false }
 
     trait :hidden do

--- a/spec/factories/page_template_elements.rb
+++ b/spec/factories/page_template_elements.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page_template_element do
-    name { "#{Faker::Science.unique.element}_#{Faker::Science.unique.element}".downcase }
+    name { Faker::Books::CultureSeries.unique.civs.parameterize }
     content_type { I18n.t( 'admin.elements.short_text' ) }
   end
 end

--- a/spec/factories/page_templates.rb
+++ b/spec/factories/page_templates.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :page_template do
-    name { Faker::Science.unique.scientist }
+    name     { Faker::Books::CultureSeries.unique.culture_ship }
     filename { 'an_example' }
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :page, aliases: [ :top_level_page ] do
-    name   { Faker::Science.unique.scientist }
+    name   { Faker::Books::CultureSeries.unique.culture_ship }
     title  { name.dup.titlecase }
-    slug   { name.dup.downcase.gsub( /[^\w\s]/, '' ).gsub( /\s+/, '-' ) }
+    slug   { name.dup.parameterize }
     hidden { false }
     association :template, factory: :page_template
 

--- a/spec/factories/setting_values.rb
+++ b/spec/factories/setting_values.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :setting_value do
-    value { Faker::Science.unique.scientist }
+    value { Faker::Books::CultureSeries.unique.culture_ship }
   end
 end

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :setting do
-    name   { "#{Faker::Science.unique.element}_#{Faker::Science.unique.element}".downcase }
+    name   { Faker::Books::CultureSeries.unique.civs.parameterize }
     level  { 'site' }
     locked { false  }
   end

--- a/spec/requests/admin/blog/posts_spec.rb
+++ b/spec/requests/admin/blog/posts_spec.rb
@@ -147,9 +147,9 @@ RSpec.describe 'Admin::Blog::Posts', type: :request do
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.blog.posts.index.title' ).titlecase
       expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.blog.posts.destroy.success' )
-      expect( response.body ).to     include p1.title
-      expect( response.body ).not_to include p2.title
-      expect( response.body ).to     include p3.title
+      expect( response.body ).to     have_css 'td', text: p1.title
+      expect( response.body ).not_to have_css 'td', text: p2.title
+      expect( response.body ).to     have_css 'td', text: p3.title
     end
 
     it 'fails gracefully when attempting to delete a non-existent blog post' do

--- a/spec/requests/admin/blogs_spec.rb
+++ b/spec/requests/admin/blogs_spec.rb
@@ -116,9 +116,9 @@ RSpec.describe 'Admin::Blogs', type: :request do
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.blogs.index.title' ).titlecase
       expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.blogs.destroy.success' )
-      expect( response.body ).to     include b1.name
-      expect( response.body ).not_to include b2.name
-      expect( response.body ).to     include b3.name
+      expect( response.body ).to     have_css 'td', text: b1.name
+      expect( response.body ).not_to have_css 'td', text: b2.name
+      expect( response.body ).to     have_css 'td', text: b3.name
     end
 
     it 'fails gracefully when attempting to delete a non-existent blog' do

--- a/spec/requests/admin/news_spec.rb
+++ b/spec/requests/admin/news_spec.rb
@@ -145,9 +145,9 @@ RSpec.describe 'Admin::News', type: :request do
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.news.index.title' ).titlecase
       expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.news.destroy.success' )
-      expect( response.body ).to     include p1.title
-      expect( response.body ).not_to include p2.title
-      expect( response.body ).to     include p3.title
+      expect( response.body ).to     have_css 'td', text: p1.title
+      expect( response.body ).not_to have_css 'td', text: p2.title
+      expect( response.body ).to     have_css 'td', text: p3.title
     end
 
     it 'fails gracefully when attempting to delete a non-existent news post' do

--- a/spec/requests/admin/pages/sections_spec.rb
+++ b/spec/requests/admin/pages/sections_spec.rb
@@ -121,9 +121,9 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.pages.index.title' ).titlecase
       expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.sections.destroy.success' )
-      expect( response.body ).to     include s1.name
-      expect( response.body ).not_to include s2.name
-      expect( response.body ).to     include s3.name
+      expect( response.body ).to     have_css 'td', text: s1.name
+      expect( response.body ).not_to have_css 'td', text: s2.name
+      expect( response.body ).to     have_css 'td', text: s3.name
     end
 
     it 'fails gracefully when attempting to delete a non-existent section' do

--- a/spec/requests/admin/pages/templates_spec.rb
+++ b/spec/requests/admin/pages/templates_spec.rb
@@ -124,8 +124,8 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.pages.templates.index.title' ).titlecase
       expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.templates.destroy.success' )
-      expect( response.body ).to     include t1.name
-      expect( response.body ).not_to include t2.name
+      expect( response.body ).to     have_css 'td', text: t1.name
+      expect( response.body ).not_to have_css 'td', text: t2.name
     end
 
     it 'fails gracefully when attempting to delete a non-existent template' do

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe 'Admin: Pages', type: :request do
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'admin.pages.index.title' ).titlecase
 
-      expect( response.body ).to include page.name
-      expect( response.body ).to include subpage.name
-      expect( response.body ).to include subpage.section.name
-      expect( response.body ).to include hidden_subpage.name
-      expect( response.body ).to include hidden_section.name
+      expect( response.body ).to have_css 'td', text: page.name
+      expect( response.body ).to have_css 'td', text: subpage.name
+      expect( response.body ).to have_css 'td', text: subpage.section.name
+      expect( response.body ).to have_css 'td', text: hidden_subpage.name
+      expect( response.body ).to have_css 'td', text: hidden_section.name
     end
   end
 
@@ -193,9 +193,9 @@ RSpec.describe 'Admin: Pages', type: :request do
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.pages.index.title' ).titlecase
       expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.pages.destroy.success' )
-      expect( response.body ).to     include p1.name
-      expect( response.body ).not_to include p2.name
-      expect( response.body ).to     include p3.name
+      expect( response.body ).to     have_css 'td', text: p1.name
+      expect( response.body ).not_to have_css 'td', text: p2.name
+      expect( response.body ).to     have_css 'td', text: p3.name
     end
 
     it 'fails gracefully when attempting to delete a non-existent page' do

--- a/spec/requests/blogs_spec.rb
+++ b/spec/requests/blogs_spec.rb
@@ -38,16 +38,12 @@ RSpec.describe 'Blogs', type: :request do
 
       get view_blog_path
 
-      # Version from my other request specs
-      expect( response ).to have_http_status :ok
-      # Version from scaffold controller spec
-      expect( response ).to be_successful
-
-      expect( response.body ).to     include post1.title
-      expect( response.body ).to     include post1.teaser
-      expect( response.body ).not_to include "shouldn't appear in the teaser!"
-      expect( response.body ).to     include post2.title
-      expect( response.body ).to     include post3.title
+      expect( response      ).to     have_http_status :ok
+      expect( response.body ).to     have_css 'h2',      text: post1.title
+      expect( response.body ).to     have_css 'section', text: 'Third is the details'
+      expect( response.body ).not_to have_css 'section', text: "shouldn't appear in the teaser!"
+      expect( response.body ).to     have_css 'h2',      text: post2.title
+      expect( response.body ).to     have_css 'h2',      text: post3.title
     end
 
     it 'throws an appropriate error if no blog exists' do

--- a/spec/requests/news_spec.rb
+++ b/spec/requests/news_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe 'News', type: :request do
       get view_news_path
 
       expect( response      ).to     have_http_status :ok
-      expect( response.body ).to     include post1.title
-      expect( response.body ).to     include post1.teaser
-      expect( response.body ).not_to include "shouldn't appear in the teaser!"
-      expect( response.body ).to     include post2.title
-      expect( response.body ).to     include post3.title
+      expect( response.body ).to     have_css 'h2',      text: post1.title
+      expect( response.body ).to     have_css 'section', text: 'Third is the details'
+      expect( response.body ).not_to have_css 'section', text: "shouldn't appear in the teaser!"
+      expect( response.body ).to     have_css 'h2',      text: post2.title
+      expect( response.body ).to     have_css 'h2',      text: post3.title
     end
 
     it 'throws an appropriate error if no news exists' do
@@ -50,7 +50,7 @@ RSpec.describe 'News', type: :request do
       get view_news_path
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to include I18n.t( 'news.index.zero_posts' )
+      expect( response.body ).to have_css 'p', text: I18n.t( 'news.index.zero_posts' )
     end
   end
 


### PR DESCRIPTION
(Also, this flushed out some tests that were fragile around content with apostrophes in. Fixed by replacing 'include' expectations with 'have_css' expectations, which presumably encodes/decodes entities the same way that Rails does.)