### PR TITLE
Heroku-related tweaks and fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source 'https://rubygems.org' do
 
   gem 'puma', '~> 4.3'
 
+  # Load ENV from .env(.*) files
+  gem 'dotenv-rails'
+
   # Reduce boot times through caching; required in config/boot.rb
   gem 'bootsnap', '>= 1.4.2', require: false
   # Use faster SCSS gem for stylesheets
@@ -48,6 +51,9 @@ source 'https://rubygems.org' do
   gem 'image_processing', '~> 1.10'
   gem 'mini_magick'
 
+  # Better-looking console output
+  gem 'awesome_print'
+
   # Pry is a debugging tool
   # Uncomment it here if you want to use it on the Rails console in production
   gem 'pry-rails'
@@ -55,10 +61,6 @@ source 'https://rubygems.org' do
   group :development, :test do
     # Debugging tool. Uncomment it here if you commented it out in production.
     # gem 'pry-rails'
-    # Better-looking console output
-    gem 'awesome_print'
-    # Load ENV from .env
-    gem 'dotenv-rails'
     # Create test objects
     gem 'factory_bot_rails'
     # Fill test objects with fake data

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings here will take precedence over those in config/application.rb
 
+  # The forgery protection seems to false positive a lot around proxies...
+  config.action_controller.forgery_protection_origin_check = false
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -21,3 +21,6 @@ Ahoy.cookies = false if ENV['AHOY_COOKIES'].presence == 'false'
 
 # Set to true for JavaScript tracking
 Ahoy.api = false
+
+# Disable geocoding until I figure out the geolite database licensing stuff
+Ahoy.geocode = false

--- a/tools/heroku-release
+++ b/tools/heroku-release
@@ -1,3 +1,4 @@
 gem uninstall bundler --version 1.17.2
-bundle exec rails assets:precompile
 bundle exec rails db:migrate
+npm install mjml
+bundle exec rails assets:precompile

--- a/tools/heroku-release
+++ b/tools/heroku-release
@@ -1,4 +1,3 @@
 gem uninstall bundler --version 1.17.2
 bundle exec rails db:migrate
-npm install mjml
 bundle exec rails assets:precompile


### PR DESCRIPTION
* Move dotenv into production area of Gemfile (rake tasks need it)
* Remove geocoding support from Ahoy stats for now - it's broken, something about licensing
* Disable forgery protection in production - not sure if this is controversial or not? It false positives a lot at work, fills our logs with crap. It seems to cope badly with proxies? It doesn't like my slightly gaffer-taped Heroku+Cloudflare SSL config, anyway.