### PR TITLE
Refactor path helpers for news posts and blog posts

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -42,38 +42,37 @@ class Admin::CommentsController < AdminController
   def hide
     authorise @comment
     @comment.hide
-    redirect_to request.referer || comment_in_context_path( @comment )
+    redirect_back fallback_location: @comment.anchored_path
   end
 
   def unhide
     authorise @comment
     @comment.unhide
-    redirect_to request.referer || comment_in_context_path( @comment )
+    redirect_back fallback_location: @comment.anchored_path
   end
 
   def lock
     authorise @comment
     @comment.lock
-    redirect_to request.referer || comment_in_context_path( @comment )
+    redirect_back fallback_location: @comment.anchored_path
   end
 
   def unlock
     authorise @comment
     @comment.unlock
-    redirect_to request.referer || comment_in_context_path( @comment )
+    redirect_back fallback_location: @comment.anchored_path
   end
 
   def delete
     authorise @comment
-    contextual_path = comment_in_context_path( @comment )
-    @comment.delete
-    redirect_to request.referer || contextual_path
+    @comment.destroy!
+    redirect_back fallback_location: @comment.anchored_path
   end
 
   def mark_as_spam
     authorise @comment
     @comment.mark_as_spam
-    redirect_to request.referer || comment_in_context_path( @comment )
+    redirect_back fallback_location: @comment.anchored_path
   end
 
   private

--- a/app/helpers/main_site_helper.rb
+++ b/app/helpers/main_site_helper.rb
@@ -37,39 +37,4 @@ module MainSiteHelper
   def user_profile_link( user = current_user )
     link_to user_display_name( user ), user_profile_path( user.username )
   end
-
-  # Returns the path to a comment's parent resource, anchored to the comment
-  # Tries to fall back gracefully if comment is deleted/marked as spam
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
-  def comment_in_context_path( comment )
-    num =
-      if comment.blank? || comment.spam?
-        'comments'
-      else
-        comment.number
-      end
-    if comment.discussion.resource_type == 'BlogPost'
-      view_blog_post_path( comment.discussion.resource ) + "##{num}"
-    elsif comment.discussion.resource_type == 'NewsPost'
-      view_news_post_path( comment.discussion.resource ) + "##{num}"
-    end
-  end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/MethodLength
-
-  def view_blog_post_path( post )
-    if Blog.multiple_blogs_mode?
-      # :nocov:
-      blog_slug = post.blog.slug
-      "/blog/#{blog_slug}/#{post.posted_year}/#{post.posted_month}/#{post.slug}"
-      # :nocov:
-    else
-      "/blog/#{post.posted_year}/#{post.posted_month}/#{post.slug}"
-    end
-  end
-
-  def view_news_post_path( post )
-    "/news/#{post.posted_year}/#{post.posted_month}/#{post.slug}"
-  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,6 +4,10 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  def url_helpers
+    Rails.application.routes.url_helpers
+  end
+
   def human_name
     name = self.class.name.underscore
     return name.humanize.downcase unless I18n.exists?( "content_types.#{name}" )

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -38,6 +38,20 @@ class BlogPost < ApplicationRecord
     self.slug = title.parameterize
   end
 
+  def path( anchor: nil )
+    if Blog.multiple_blogs_mode?
+      # :nocov:
+      url_helpers.view_blog_post_path(
+        blog.slug, posted_year, posted_month, slug, anchor: anchor
+      )
+      # :nocov:
+    else
+      url_helpers.view_blog_post_path(
+        posted_year, posted_month, slug, anchor: anchor
+      )
+    end
+  end
+
   def posted_month
     posted_at.strftime( '%m' )
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -32,6 +32,15 @@ class Comment < ApplicationRecord
     self.number = ( discussion.comments.maximum( :number ) || 0 ) + 1
   end
 
+  # Returns the path to a comment's parent resource, anchored to the comment
+  # Tries to fall back gracefully if comment is deleted/marked as spam
+  def anchored_path
+    anchor = number
+    anchor = 'comments' if destroyed? || spam?
+
+    discussion.resource.path( anchor: anchor )
+  end
+
   def send_notifications
     p = parent.notification_email if parent.present?
     notify_parent_comment_author if p.present?

--- a/app/models/news_post.rb
+++ b/app/models/news_post.rb
@@ -37,6 +37,12 @@ class NewsPost < ApplicationRecord
     self.slug = title.parameterize
   end
 
+  def path( anchor: nil )
+    url_helpers.view_news_post_path(
+      posted_year, posted_month, slug, anchor: anchor
+    )
+  end
+
   def posted_month
     posted_at.strftime( '%m' )
   end

--- a/app/views/admin/blog/posts/index.html.erb
+++ b/app/views/admin/blog/posts/index.html.erb
@@ -31,7 +31,7 @@
         <%= post.posted_at.to_s( :time ) %> on <%= post.posted_at.to_s( :shinydate ) %>
       </td>
       <td class="actions">
-        <%= link_to t( 'view'   ), view_blog_post_path( post ) %>
+        <%= link_to t( 'view'   ), post.path %>
         <%= link_to t( 'edit'   ), edit_blog_post_path( post.blog, post ) %>
         <%= link_to t( 'delete' ), blog_post_path( post.blog, post ),
             method: :delete, data: { confirm: t( 'are_you_sure' ) } %>

--- a/app/views/admin/news/index.html.erb
+++ b/app/views/admin/news/index.html.erb
@@ -31,7 +31,7 @@
         <%= post.posted_at.to_s( :time ) %> on <%= post.posted_at.to_s( :shinydate ) %>
       </td>
       <td class="actions">
-        <%= link_to t( 'view'   ), view_news_post_path( post ) %>
+        <%= link_to t( 'view'   ), post.path %>
         <%= link_to t( 'edit'   ), edit_news_post_path( post ) %>
         <%= link_to t( 'delete' ), news_post_path( post ),
             method: :delete, data: { confirm: t( 'are_you_sure' ) } %>

--- a/app/views/shinycms/blogs/_post_in_list.erb
+++ b/app/views/shinycms/blogs/_post_in_list.erb
@@ -8,7 +8,7 @@
     <% comment_count = post.discussion.comments.count %>
     <% comments_word = t( 'discussions.comments' ).downcase %>
     <% comment_word.singularize if comment_count == 1 %>
-    <%= link_to "#{comment_count} #{comments_word}", view_blog_post_path( post ) + '#comments' %>
+    <%= link_to "#{comment_count} #{comments_word}", post.path( anchor: 'comments' ) %>
 
   <% else %>
     <i>Comments have been disabled on this post</i>

--- a/app/views/shinycms/blogs/_post_in_list_header.erb
+++ b/app/views/shinycms/blogs/_post_in_list_header.erb
@@ -1,6 +1,6 @@
   <header>
     <h2>
-      <%= link_to post.title, view_blog_post_path( post ) %>
+      <%= link_to post.title, post.path %>
     </h2>
     <h3>
       Posted by <%= user_profile_link( post.author ) %>

--- a/app/views/shinycms/menu/_blog.html.erb
+++ b/app/views/shinycms/menu/_blog.html.erb
@@ -5,7 +5,7 @@
     <% menu_posts = menu_blog.recent_posts.per( 5 ) %>
     <% menu_posts.each do |menu_post| %>
     <li>
-      <%= link_to menu_post.title, view_blog_post_path( menu_post ) %>
+      <%= link_to menu_post.title, menu_post.path %>
     </li>
     <% end %>
   </ul>

--- a/app/views/shinycms/news/index.html.erb
+++ b/app/views/shinycms/news/index.html.erb
@@ -9,7 +9,7 @@
 
   <header>
     <h2>
-      <%= link_to post.title, view_news_post_path( post ) %>
+      <%= link_to post.title, post.path %>
     </h2>
     <h3>
       Posted by <%= user_profile_link( post.author ) %>

--- a/app/views/shinycms/news/month.html.erb
+++ b/app/views/shinycms/news/month.html.erb
@@ -10,7 +10,7 @@
 <section>
   <header>
     <h2>
-      <%= link_to post.title, view_news_post_path( post ) %>
+      <%= link_to post.title, post.path %>
     </h2>
     <h3>
       Posted by <%= user_profile_link( post.author ) %>

--- a/app/views/shinycms/news/show.html.erb
+++ b/app/views/shinycms/news/show.html.erb
@@ -6,7 +6,7 @@
 
   <header>
     <h2>
-      <%= link_to @post.title, view_news_post_path( @post ) %>
+      <%= link_to @post.title, @post.path %>
     </h2>
     <h3>
       Posted by <%= user_profile_link( @post.author ) %>

--- a/app/views/shinycms/news/year.html.erb
+++ b/app/views/shinycms/news/year.html.erb
@@ -14,7 +14,7 @@
   <section>
     <header>
       <h2>
-        <%= link_to post.title, view_blog_post_path( post ) %>
+        <%= link_to post.title, post.path %>
       </h2>
       <h3>
         Posted by <%= user_profile_link( post.author ) %>

--- a/app/views/shinycms/tags/show.html.erb
+++ b/app/views/shinycms/tags/show.html.erb
@@ -12,7 +12,7 @@
       <% @tagged_items[ type ].each do |item| %>
       <li>
         <% if type == 'BlogPost' %>
-        <%= link_to item.title, view_blog_post_path( item ) %>
+        <%= link_to item.title, item.path %>
           posted by <%= user_profile_link( item.author ) %>
           at <%= item.posted_at.to_s( :time ) %>
           on <%= item.posted_at.to_s( :shinydate ) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
       # :nocov:
     else
       get 'blog',                     to: 'blogs#recent', as: :view_blog
-      get 'blog/:year/:month/:slug',  to: 'blogs#show',   as: :ignore1,
+      get 'blog/:year/:month/:slug',  to: 'blogs#show',   as: :view_blog_post,
                                       constraints: {
                                         year: %r{\d\d\d\d},
                                         month: %r{\d\d}
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
     post 'discussion/:id/:number', to: 'discussions#add_reply'
 
     get 'news',                     to: 'news#index', as: :view_news
-    get 'news/:year/:month/:slug',  to: 'news#show',  as: :ignore4,
+    get 'news/:year/:month/:slug',  to: 'news#show',  as: :view_news_post,
                                     constraints: {
                                       year: %r{\d\d\d\d},
                                       month: %r{\d\d}

--- a/spec/requests/admin/comments_spec.rb
+++ b/spec/requests/admin/comments_spec.rb
@@ -23,19 +23,6 @@ RSpec.describe 'Comment moderation', type: :request do
     @comment2 = create :top_level_comment, discussion: @discussion2
   end
 
-  # TODO: Can I use the real helper method here instead of this nasty copypasta?
-  def comment_in_context_path( comment )
-    post = comment.discussion.resource
-    type = 'blog'
-    type = 'news' if comment.discussion.resource_type == 'NewsPost'
-
-    if comment.blank? || comment.spam?
-      return "/#{type}/#{post.posted_year}/#{post.posted_month}/#{post.slug}#comments"
-    end
-
-    "/#{type}/#{post.posted_year}/#{post.posted_month}/#{post.slug}##{comment.number}"
-  end
-
   describe 'GET /admin/comments' do
     it 'fetches the spam comment moderation page' do
       get comments_path
@@ -139,7 +126,7 @@ RSpec.describe 'Comment moderation', type: :request do
       get hide_comment_path( @comment1 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to comment_in_context_path( @comment1 )
+      expect( response      ).to     redirect_to @comment1.anchored_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_css 'h2', text: @nested1.title
@@ -156,7 +143,7 @@ RSpec.describe 'Comment moderation', type: :request do
       get unhide_comment_path( @comment1 )
 
       expect( response      ).to     have_http_status :found
-      expect( response      ).to     redirect_to comment_in_context_path( @comment1 )
+      expect( response      ).to     redirect_to @comment1.anchored_path
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_css 'h2', text: @nested1.title
@@ -170,7 +157,7 @@ RSpec.describe 'Comment moderation', type: :request do
       get lock_comment_path( @comment2 )
 
       expect( response ).to have_http_status :found
-      expect( response ).to redirect_to comment_in_context_path( @comment2 )
+      expect( response ).to redirect_to @comment2.anchored_path
       follow_redirect!
       expect( response ).to have_http_status :ok
 
@@ -186,7 +173,7 @@ RSpec.describe 'Comment moderation', type: :request do
       get unlock_comment_path( @comment2 )
 
       expect( response ).to have_http_status :found
-      expect( response ).to redirect_to comment_in_context_path( @comment2 )
+      expect( response ).to redirect_to @comment2.anchored_path
       follow_redirect!
       expect( response ).to have_http_status :ok
 
@@ -200,7 +187,7 @@ RSpec.describe 'Comment moderation', type: :request do
       @comment1.reload
 
       expect( response ).to have_http_status :found
-      expect( response ).to redirect_to comment_in_context_path( @comment1 )
+      expect( response ).to redirect_to @comment1.anchored_path
       follow_redirect!
       expect( response ).to have_http_status :ok
 
@@ -213,7 +200,7 @@ RSpec.describe 'Comment moderation', type: :request do
       delete delete_comment_path( @comment2 )
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to comment_in_context_path( @comment2 )
+      expect( response      ).to redirect_to @news.path( anchor: 'comments' )
       follow_redirect!
       expect( response      ).to have_http_status :ok
       expect( response.body ).not_to include @comment2.title


### PR DESCRIPTION
Keeps the code cleaner by:
* Keeping the path-generation code closer to each object, rather than a big if/elsif blocks in the helper
* Leveraging the routes file definition rather than reimplementing it in the helper