### PR TITLE
Fix two bugs relating to when theme_name isn't set (fixes #321)

### DIFF
--- a/app/models/page_template.rb
+++ b/app/models/page_template.rb
@@ -46,13 +46,15 @@ class PageTemplate < ApplicationRecord
   # Class methods
 
   def self.template_dir
-    return '' if Theme.current.blank?
+    return if Theme.current.blank?
 
     Rails.root.join Theme.current.page_templates_path
   end
 
   # Get a list of available template files from the disk
   def self.available_templates
+    return unless template_dir
+
     filenames = Dir.glob '*.html.erb', base: template_dir
     template_names = []
     filenames.each do |filename|

--- a/app/models/page_template.rb
+++ b/app/models/page_template.rb
@@ -46,6 +46,8 @@ class PageTemplate < ApplicationRecord
   # Class methods
 
   def self.template_dir
+    return '' if Theme.current.blank?
+
     Rails.root.join Theme.current.page_templates_path
   end
 

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -24,6 +24,8 @@ namespace :shiny do
       @shiny_admin.save!
       @shiny_admin.grant_all_capabilities
 
+      Setting.set :theme_name, to: 'halcyonic'
+
       PageTemplate.skip_callback( :create, :after, :add_elements )
       Page.skip_callback( :create, :after, :add_elements )
 


### PR DESCRIPTION
* rails shiny:demo:load needs to set theme_name SettingValue before it tries to create PageTemplate records (otherwise the test for the template file existing on disk will fail)
* When no theme name is set, there is no page templates directory available - so template_dir and available_templates are both blank