### PR TITLE
Fix discussion tests (again)

### DIFF
--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Discussion, type: :model do
         @active_this_week = create :news_post
         @active_last_week = create :news_post
 
-        create :discussion, comment_count: rand(5), resource: @less_active_post
-        create :discussion, comment_count: 5, resource: @active_this_week
-        create :discussion, comment_count: 6, comments_posted_at: 8.days.ago, resource: @active_last_week
+        create :discussion, resource: @less_active_post, comment_count: rand(5)
+        create :discussion, resource: @active_this_week, comment_count: 5
+        create :discussion, resource: @active_last_week, comment_count: 6, comments_posted_at: 8.days.ago
       end
 
       describe 'without params' do

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -15,13 +15,15 @@ RSpec.describe Discussion, type: :model do
   context 'methods' do
     context '.recently_active' do
       before :each do
-        @less_active_post = create :news_post
-        @active_this_week = create :news_post
         @active_last_week = create :news_post
+        @active_this_week = create :news_post
+        @less_active_post = create :news_post
+        @an_inactive_post = create :news_post
 
-        create :discussion, resource: @less_active_post, comment_count: rand(5)
-        create :discussion, resource: @active_this_week, comment_count: 5
-        create :discussion, resource: @active_last_week, comment_count: 6, comments_posted_at: 8.days.ago
+        create :discussion, resource: @active_last_week, comment_count: 5, comments_posted_at: 8.days.ago
+        create :discussion, resource: @active_this_week, comment_count: 4
+        create :discussion, resource: @less_active_post, comment_count: rand(1..3)
+        create :discussion, resource: @an_inactive_post, comment_count: 0
       end
 
       describe 'without params' do
@@ -29,7 +31,7 @@ RSpec.describe Discussion, type: :model do
           active, counts = Discussion.recently_active
 
           expect( active.length ).to eq 2
-          expect( active.find( counts.first.first ).resource ).to eq @active_this_week
+          expect( active.find( counts.to_h.keys.first ).resource ).to eq @active_this_week
         end
       end
 
@@ -38,7 +40,18 @@ RSpec.describe Discussion, type: :model do
           active, counts = Discussion.recently_active( days: 14 )
 
           expect( active.length ).to eq 3
-          expect( active.find( counts.first.first ).resource ).to eq @active_last_week
+          expect( active.find( counts.to_h.keys.first ).resource ).to eq @active_last_week
+        end
+      end
+
+      describe 'when discussions have no comments' do
+        it "doesn't include them" do
+          active, _counts = Discussion.recently_active
+
+          expect( active.length ).to eq 2
+          # TODO: expect( active.resources ).not_to include @an_inactive_post
+          expect( active.first.resource  ).not_to eq @an_inactive_post
+          expect( active.second.resource ).not_to eq @an_inactive_post
         end
       end
     end


### PR DESCRIPTION
Pinned down wobbly test - due to one of the created discussions sometimes having zero comments and hence not being 'active'. Added explicit test for this (correct) behaviour, and made sure it doesn't happen in the other tests to confuse them.