### PR TITLE
Use .implicit_order_column instead of default_scope to always sort by sort_order

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -29,9 +29,7 @@ class Page < ApplicationRecord
 
   # Scopes
 
-  # rubocop:disable Rails/DefaultScope
-  default_scope { order( :sort_order ) }
-  # rubocop:enable Rails/DefaultScope
+  self.implicit_order_column = 'sort_order'
 
   scope :top_level,        -> { where( section: nil ) }
   scope :visible,          -> { where( hidden: false ) }

--- a/app/models/page_section.rb
+++ b/app/models/page_section.rb
@@ -27,9 +27,7 @@ class PageSection < ApplicationRecord
 
   # Scopes
 
-  # rubocop:disable Rails/DefaultScope
-  default_scope { order( :sort_order ) }
-  # rubocop:enable Rails/DefaultScope
+  self.implicit_order_column = 'sort_order'
 
   scope :top_level,        -> { where( section: nil  ) }
   scope :visible,          -> { where( hidden: false ) }

--- a/spec/models/page_section_spec.rb
+++ b/spec/models/page_section_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'PageSection model:', type: :model do
-  context 'when I call .default_page' do
+  describe 'when I call .default_page' do
     it 'with no default set, it returns the first page created in this section' do
       section = create :page_section
 
@@ -25,7 +25,7 @@ RSpec.describe 'PageSection model:', type: :model do
     end
   end
 
-  context 'when I call PageSection.default_section' do
+  describe 'when I call PageSection.default_section' do
     it 'it returns the correct section' do
       create :page_section
       section2 = create :page_section, slug: 'default'
@@ -33,6 +33,20 @@ RSpec.describe 'PageSection model:', type: :model do
       Setting.set( :default_section, to: 'default' )
 
       expect( PageSection.default_section ).to eq section2
+    end
+  end
+
+  describe 'check that sort_order is applied' do
+    it 'returns the sections ordered by sort_order, nulls last (not by .id or .created_at)' do
+      s1 = create :page_section, sort_order: 6
+      s2 = create :page_section
+      s3 = create :page_section, sort_order: 2
+      s4 = create :page_section, sort_order: 5
+
+      expect( PageSection.first  ).to eq s3
+      expect( PageSection.second ).to eq s4
+      expect( PageSection.third  ).to eq s1
+      expect( PageSection.last   ).to eq s2
     end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Page model:', type: :model do
-  context 'when I call Page.default_page' do
+  describe 'when I call Page.default_page' do
     it 'without a setting, it returns the first page created' do
       page1 = create :page, slug: 'first'
       create :page, slug: 'default'
@@ -18,6 +18,20 @@ RSpec.describe 'Page model:', type: :model do
       Setting.set( :default_page, to: 'default' )
 
       expect( Page.default_page ).to eq page2
+    end
+  end
+
+  describe 'check that sort_order is applied' do
+    it 'returns the pages ordered by sort_order, nulls last (not by .id or .created_at)' do
+      p1 = create :page, sort_order: 6
+      p2 = create :page
+      p3 = create :page, sort_order: 2
+      p4 = create :page, sort_order: 5
+
+      expect( Page.first  ).to eq p3
+      expect( Page.second ).to eq p4
+      expect( Page.third  ).to eq p1
+      expect( Page.last   ).to eq p2
     end
   end
 end


### PR DESCRIPTION
(in pages and page_sections)