### PR TITLE
Add rubocop and bundle audit to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,16 @@ jobs:
           paths:
             - ~/ShinyCMS/vendor/bundle
 
+      # Run Rubocop to check linting
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop
+
+      # Run bundle-audit to check gems for known security issues
+      - run:
+          name: Audit Gemfile bundle for security issues
+          command: bundle exec bundle-audit check --update
+
       # Restore Node dependencies from cache, or install them
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       # Run Rubocop to check linting
       - run:
           name: Rubocop
-          command: bundle exec rubocop --force-exclusion
+          command: bundle exec rubocop app/ config/ db/ lib/ plugins/ spec/
 
       # Run bundle-audit to check gems for known security issues
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       # Run Rubocop to check linting
       - run:
           name: Rubocop
-          command: bundle exec rubocop
+          command: bundle exec rubocop --force-exclusion
 
       # Run bundle-audit to check gems for known security issues
       - run:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - public/**/*
     - tmp/**/*
     - tools/**/*
-    - vendor/*
+    - vendor/bundle/ruby/2.7.0/gems/**/*
 
 # Disabling cops for a few lines here and there is handy
 Style/DisableCopsWithinSourceCodeDirective:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,18 +5,19 @@ require: rubocop-rails
 AllCops:
   EnabledByDefault: true
   Exclude:
-    - bin/*
     - app/assets/**/*
+    - bin/*
     - coverage/**/*
+    - db/schema.rb
+    - db/migrate/*.rb
     - docs/*
     - log/*
     - node_modules/**/*
+    - plugins/*/db/migrate/*.rb
     - public/**/*
     - tmp/**/*
     - tools/**/*
-    - db/schema.rb
-    - db/migrate/*.rb
-    - plugins/*/db/migrate/*.rb
+    - vendor/*
 
 # Disabling cops for a few lines here and there is handy
 Style/DisableCopsWithinSourceCodeDirective:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,6 @@ AllCops:
     - public/**/*
     - tmp/**/*
     - tools/**/*
-    - vendor/bundle/ruby/2.7.0/gems/**/*
 
 # Disabling cops for a few lines here and there is handy
 Style/DisableCopsWithinSourceCodeDirective:


### PR DESCRIPTION
NB: Had to specify the directories to run Rubocop against, otherwise it insisted on checking all the faily gem code in the vendor/ directory no matter what my config excluded.