### PR TITLE
Convert symbols to strings before using .start_with? on them

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -59,7 +59,7 @@ class AdminController < ApplicationController
   end
 
   def path_for( area = nil )
-    return Plugin.new( area ).admin_index_path if area.start_with? 'shiny_'
+    return Plugin.new( area ).admin_index_path if area.to_s.start_with? 'shiny_'
 
     area = :root if area.blank?
     area = :admin_site_settings if area == :settings

--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -5,7 +5,7 @@ class Plugin
   attr_accessor :name, :this
 
   def initialize( name )
-    name = Plugin.capability_category_to_plugin_name( name ) if name.start_with? 'shiny_'
+    name = Plugin.capability_category_to_plugin_name( name ) if name.to_s.start_with? 'shiny_'
     return unless Plugin.all.include? name
 
     @name = name


### PR DESCRIPTION
:symbol.start_with? works in ruby 2.7.1 but not in 2.6.6 or earlier