### PR TITLE
Fix copypasta error in plugin pundit policies

### DIFF
--- a/plugins/ShinyBlog/app/policies/shiny_blog/post_policy.rb
+++ b/plugins/ShinyBlog/app/policies/shiny_blog/post_policy.rb
@@ -21,7 +21,7 @@ module ShinyBlog
     end
 
     def new?
-      @this_user.can? :list, :blog_posts
+      @this_user.can? :add, :blog_posts
     end
 
     def create?

--- a/plugins/ShinyForms/app/policies/shiny_forms/form_policy.rb
+++ b/plugins/ShinyForms/app/policies/shiny_forms/form_policy.rb
@@ -21,7 +21,7 @@ module ShinyForms
     end
 
     def new?
-      @this_user.can? :list, :forms
+      @this_user.can? :add, :forms
     end
 
     def create?

--- a/plugins/ShinyNews/app/policies/shiny_news/post_policy.rb
+++ b/plugins/ShinyNews/app/policies/shiny_news/post_policy.rb
@@ -21,7 +21,7 @@ module ShinyNews
     end
 
     def new?
-      @this_user.can? :list, :news_posts
+      @this_user.can? :add, :news_posts
     end
 
     def create?

--- a/plugins/ShinyPages/app/policies/shiny_pages/page_policy.rb
+++ b/plugins/ShinyPages/app/policies/shiny_pages/page_policy.rb
@@ -21,7 +21,7 @@ module ShinyPages
     end
 
     def new?
-      @this_user.can? :list, :pages
+      @this_user.can? :add, :pages
     end
 
     def create?

--- a/plugins/ShinyPages/app/policies/shiny_pages/section_policy.rb
+++ b/plugins/ShinyPages/app/policies/shiny_pages/section_policy.rb
@@ -21,7 +21,7 @@ module ShinyPages
     end
 
     def new?
-      @this_user.can? :list, :pages
+      @this_user.can? :add, :pages
     end
 
     def create?

--- a/plugins/ShinyPages/app/policies/shiny_pages/template_policy.rb
+++ b/plugins/ShinyPages/app/policies/shiny_pages/template_policy.rb
@@ -21,7 +21,7 @@ module ShinyPages
     end
 
     def new?
-      @this_user.can? :list, :page_templates
+      @this_user.can? :add, :page_templates
     end
 
     def create?


### PR DESCRIPTION
Several of the existing plugins have the same error in their pundit policies (the add? method responds based on whether the user has permission to list, not add) which this PR fixes.