### PR TITLE
Pre-emptive rubocop fixes

### DIFF
--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -70,7 +70,7 @@ namespace :shiny do
     end
 
     def fix_primary_key_sequence( table_name )
-      ActiveRecord::Base.connection.execute(<<~SQL)
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
         BEGIN;
         LOCK TABLE #{table_name} IN EXCLUSIVE MODE;
         SELECT setval( '#{table_name}_id_seq', COALESCE( ( SELECT MAX(id)+1 FROM #{table_name} ), 1 ), false );

--- a/spec/support/shared_examples/shiny_post_example.rb
+++ b/spec/support/shared_examples/shiny_post_example.rb
@@ -76,7 +76,7 @@ RSpec.shared_examples ShinyPost do
     describe '.not_future_dated' do
       it "returns posts that aren't future-dated" do
         expect( post.class.not_future_dated.size ).to eq 3
-        expect( post.class.not_future_dated.order( :id ).last ).to eq @hidden
+        expect( post.class.not_future_dated.order( :created_at ).last ).to eq @hidden
       end
     end
 


### PR DESCRIPTION
These are the actual code changes that Rubocop 2.8.0 required... before exploding in a shower of shrapnel that means it fails CI even when all the cops pass.