### PR TITLE
Fix occasional false-positive test failures caused by short usernames

### DIFF
--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -13,10 +13,6 @@
 * Add tests for form actions being what they're supposed to be on new/edit pages, and for
   delete links being correct on list pages (to catch path helper issues)
 
-* Add exact_text option to capybara matcher calls in request specs
-  * expect(bar).to have_[field/whatever], text: 'foo', exact_text: true
-  * NB: Try one first; might fail on whitespace differences :eyeroll:
-
 * Check for and add missing indexes - https://pawelurbanek.com/rails-postgres-join-indexes
 
 * Catch Pundit::NotAuthorizedError and output `head :unauthorized` (currently 500s I think?)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,7 +9,7 @@
 # Factory for User model (note, plugins tend to add to this collection)
 FactoryBot.define do
   factory :user do
-    username     { Faker::Internet.unique.username }
+    username     { Faker::Internet.unique.username( specifier: 5 ) }
     password     { Faker::Internet.unique.password }
     email        { Faker::Internet.unique.email( name: username ) }
     confirmed_at { Time.current }


### PR DESCRIPTION
In particular, 'ed' manages to be a partial match for all kinds of longer test data, and hence breaks .not_to tests semi-regularly.

(The exact_match param (mentioned in removed section of TODO) unsurprisingly breaks with whitespace around the text, which is pretty unavoidable if you want readable HTML in your templates. Hence the alternative solution of a minimum username length.)