### PR TITLE
Fix page section+template edit actions

### DIFF
--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -2,8 +2,6 @@
 
 ## Fixes and refactoring of code already written - to do next/soon
 
-* Find and fix bug causing issues when trying to move a top-level section into another top-level section
-
 * Move pages, newsletters, and forms test templates into each plugin's spec/fixtures
 
 * Highlight section name in admin area menu when on a page which isn't in the menu

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -2,6 +2,8 @@
 
 ## Fixes and refactoring of code already written - to do next/soon
 
+* Find and fix bug causing issues when trying to move a top-level section into another top-level section
+
 * Move pages, newsletters, and forms test templates into each plugin's spec/fixtures
 
 * Highlight section name in admin area menu when on a page which isn't in the menu

--- a/plugins/ShinyPages/app/controllers/shiny_pages/admin/sections_controller.rb
+++ b/plugins/ShinyPages/app/controllers/shiny_pages/admin/sections_controller.rb
@@ -63,7 +63,7 @@ module ShinyPages
     private
 
     def section_params
-      params.require( :page_section ).permit(
+      params.require( :section ).permit(
         :internal_name, :public_name, :slug, :description, :section_id,
         :position, :show_on_site, :show_in_menus
       )

--- a/plugins/ShinyPages/app/controllers/shiny_pages/admin/templates_controller.rb
+++ b/plugins/ShinyPages/app/controllers/shiny_pages/admin/templates_controller.rb
@@ -66,7 +66,7 @@ module ShinyPages
     private
 
     def template_params
-      params.require( :page_template ).permit(
+      params.require( :template ).permit(
         :name, :description, :filename, elements_attributes: {}
       )
     end

--- a/plugins/ShinyPages/app/views/shiny_pages/admin/pages/new.html.erb
+++ b/plugins/ShinyPages/app/views/shiny_pages/admin/pages/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for :page, url: shiny_pages.pages_path, method: :post do |f| %>
+<%= form_for @page, url: shiny_pages.pages_path, method: :post do |f| %>
   <p>
     <%= f.label :internal_name %><br>
     <%= f.text_field :internal_name %>

--- a/plugins/ShinyPages/app/views/shiny_pages/admin/sections/new.html.erb
+++ b/plugins/ShinyPages/app/views/shiny_pages/admin/sections/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for :page_section, url: shiny_pages.sections_path, method: :post do |f| %>
+<%= form_for @section, url: shiny_pages.sections_path, method: :post do |f| %>
   <p>
     <%= f.label :internal_name %><br>
     <%= f.text_field :internal_name %>

--- a/plugins/ShinyPages/app/views/shiny_pages/admin/templates/new.html.erb
+++ b/plugins/ShinyPages/app/views/shiny_pages/admin/templates/new.html.erb
@@ -1,6 +1,6 @@
 <% @page_title = t( '.title' ) %>
 
-<%= form_for :page_template, url: shiny_pages.templates_path, method: :post do |f| %>
+<%= form_for @template, url: shiny_pages.templates_path, method: :post do |f| %>
   <p>
     <%= f.label :name %>
     <br><%= f.text_field :name %>

--- a/plugins/ShinyPages/config/locales/en.yml
+++ b/plugins/ShinyPages/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
           failure: Failed to delete page
 
       sections:
-        title: Page sections
+        title: Pages
         new:
           title: Add new section
         edit:

--- a/plugins/ShinyPages/spec/requests/admin/pages_spec.rb
+++ b/plugins/ShinyPages/spec/requests/admin/pages_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe 'Admin: Pages', type: :request do
   describe 'POST /admin/page/new' do
     it 'fails when the form is submitted without all the details' do
       post shiny_pages.pages_path, params: {
-        'page[public_name]': 'Test'
+        page: {
+          public_name: 'Test'
+        }
       }
 
       expect( response      ).to have_http_status :ok
@@ -56,9 +58,11 @@ RSpec.describe 'Admin: Pages', type: :request do
       template = create :page_template
 
       post shiny_pages.pages_path, params: {
-        'page[internal_name]': 'Test',
-        'page[slug]': 'account',
-        'page[template_id]': template.id
+        page: {
+          internal_name: 'Test',
+          slug: 'account',
+          template_id: template.id
+        }
       }
 
       expect( response      ).to have_http_status :ok
@@ -70,8 +74,10 @@ RSpec.describe 'Admin: Pages', type: :request do
       template = create :page_template
 
       post shiny_pages.pages_path, params: {
-        'page[internal_name]': 'Test',
-        'page[template_id]': template.id
+        page: {
+          internal_name: 'Test',
+          template_id: template.id
+        }
       }
 
       expect( response      ).to have_http_status :found
@@ -86,9 +92,10 @@ RSpec.describe 'Admin: Pages', type: :request do
       template = create :page_template
 
       post shiny_pages.pages_path, params: {
-        'page[internal_name]': 'Test',
-        'page[slug]': 'test',
-        'page[template_id]': template.id
+        page: {
+          internal_name: 'Test',
+          template_id: template.id
+        }
       }
 
       expect( response      ).to have_http_status :found
@@ -136,7 +143,9 @@ RSpec.describe 'Admin: Pages', type: :request do
       page = create :top_level_page
 
       put shiny_pages.page_path( page ), params: {
-        'page[internal_name]': ''
+        page: {
+          internal_name: ''
+        }
       }
 
       expect( response      ).to have_http_status :ok
@@ -148,7 +157,9 @@ RSpec.describe 'Admin: Pages', type: :request do
       page = create :top_level_page
 
       put shiny_pages.page_path( page ), params: {
-        'page[internal_name]': 'Updated by test'
+        page: {
+          internal_name: 'Updated by test'
+        }
       }
 
       expect( response      ).to have_http_status :found
@@ -165,8 +176,10 @@ RSpec.describe 'Admin: Pages', type: :request do
       old_slug = page.slug
 
       put shiny_pages.page_path( page ), params: {
-        'page[internal_name]': 'Updated by test',
-        'page[slug]': ''
+        page: {
+          internal_name: 'Updated by test',
+          slug: ''
+        }
       }
 
       expect( response      ).to     have_http_status :found

--- a/plugins/ShinyPages/spec/requests/admin/sections_spec.rb
+++ b/plugins/ShinyPages/spec/requests/admin/sections_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
   describe 'POST /admin/pages/section/new' do
     it 'fails when the form is submitted without all the details' do
       post shiny_pages.sections_path, params: {
-        page_section: {
+        section: {
           public_name: Faker::Books::CultureSeries.unique.culture_ship
         }
       }
@@ -44,7 +44,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
 
     it 'fails if top-level section slug collides with a controller namespace' do
       post shiny_pages.sections_path, params: {
-        page_section: {
+        section: {
           internal_name: Faker::Books::CultureSeries.unique.culture_ship,
           slug: 'tags'
         }
@@ -59,7 +59,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       ship_name = Faker::Books::CultureSeries.unique.culture_ship
 
       post shiny_pages.sections_path, params: {
-        page_section: {
+        section: {
           internal_name: ship_name,
           slug: ship_name.parameterize
         }
@@ -90,7 +90,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       section = create :page_section
 
       put shiny_pages.section_path( section ), params: {
-        page_section: {
+        section: {
           internal_name: nil
         }
       }
@@ -104,7 +104,7 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       section = create :page_section
 
       put shiny_pages.section_path( section ), params: {
-        page_section: {
+        section: {
           internal_name: 'Updated by test'
         }
       }
@@ -116,6 +116,25 @@ RSpec.describe 'Admin: Page Sections', type: :request do
       expect( response.body ).to have_title I18n.t( 'shiny_pages.admin.sections.edit.title' ).titlecase
       expect( response.body ).to have_css '.alert-success', text: I18n.t( 'shiny_pages.admin.sections.update.success' )
       expect( response.body ).to have_field 'section[internal_name]', with: 'Updated by test'
+    end
+
+    it 'moves a top-level section inside another section' do
+      section1 = create :page_section
+      section2 = create :page_section
+
+      put shiny_pages.section_path( section1 ), params: {
+        section: {
+          section_id: section2.id
+        }
+      }
+
+      expect( response      ).to have_http_status :found
+      expect( response      ).to redirect_to shiny_pages.edit_section_path( section1 )
+      follow_redirect!
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_title I18n.t( 'shiny_pages.admin.sections.edit.title' ).titlecase
+      expect( response.body ).to have_css '.alert-success', text: I18n.t( 'shiny_pages.admin.sections.update.success' )
+      expect( response.body ).to have_field 'section[section_id]', with: section2.id
     end
   end
 

--- a/plugins/ShinyPages/spec/requests/admin/templates_spec.rb
+++ b/plugins/ShinyPages/spec/requests/admin/templates_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe 'Admin: Page Templates', type: :request do
   describe 'POST /admin/pages/template/new' do
     it 'fails when the form is submitted without all the details' do
       post shiny_pages.templates_path, params: {
-        'page_template[filename]': 'Test'
+        template: {
+          filename: 'Test'
+        }
       }
 
       expect( response      ).to have_http_status :ok
@@ -42,8 +44,10 @@ RSpec.describe 'Admin: Page Templates', type: :request do
 
     it 'adds a new template when the form is submitted' do
       post shiny_pages.templates_path, params: {
-        'page_template[name]': 'Test',
-        'page_template[filename]': 'an_example'
+        template: {
+          name: 'Test',
+          filename: 'an_example'
+        }
       }
 
       expect( response      ).to have_http_status :found
@@ -55,8 +59,10 @@ RSpec.describe 'Admin: Page Templates', type: :request do
 
     it 'adds the right number of elements to the new template' do
       post shiny_pages.templates_path, params: {
-        'page_template[name]': 'Another Test',
-        'page_template[filename]': 'an_example'
+        template: {
+          name: 'Another Test',
+          filename: 'an_example'
+        }
       }
 
       expect( response      ).to have_http_status :found
@@ -84,7 +90,9 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       template = create :page_template
 
       put shiny_pages.template_path( template ), params: {
-        'page_template[name]': nil
+        template: {
+          name: nil
+        }
       }
 
       expect( response      ).to have_http_status :ok
@@ -97,10 +105,14 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       e_id = ShinyPages::TemplateElement.last.id
 
       put shiny_pages.template_path( template ), params: {
-        'page_template[name]': 'Updated by test',
-        "elements[element_#{e_id}_name]": 'updated_element_name',
-        "elements[element_#{e_id}_content]": 'Default content',
-        "elements[element_#{e_id}_type]": 'html'
+        template: {
+          name: 'Updated by test'
+        },
+        elements: {
+          "element_#{e_id}_name": 'updated_element_name',
+          "element_#{e_id}_content": 'Default content',
+          "element_#{e_id}_type": 'html'
+        }
       }
 
       expect( response      ).to have_http_status :found


### PR DESCRIPTION
Inconsistent param naming between the new and edit actions for page sections and page templates meant that the edit feature for both was broken (failed at the strong params check).