### PR TITLE
Implement discussion creation

### DIFF
--- a/app/helpers/shiny_date_helper.rb
+++ b/app/helpers/shiny_date_helper.rb
@@ -38,7 +38,7 @@ module ShinyDateHelper
     timestamp.localtime.to_s :time
   end
 
-  def combine_date_and_time_inputs( params_hash, date_input_name )
+  def combine_date_and_time_params( params_hash, date_input_name )
     date_string = params_hash[ date_input_name ]
     time_string = params_hash.delete( "#{date_input_name}_time" )
 

--- a/app/lib/shiny_discussion_admin.rb
+++ b/app/lib/shiny_discussion_admin.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Methods that any admin controller handling content with a Discussions might want
+module ShinyDiscussionAdmin
+  def extract_discussion_flags_from_params( request_params )
+    show = ( request_params.delete( :discussion_show_on_site ) || 0 ).to_i == 1
+    lock = ( request_params.delete( :discussion_locked       ) || 0 ).to_i == 1
+
+    [ show, lock ]
+  end
+
+  def create_discussion_or_update_flags( resource, show, lock )
+    if resource.discussion.present?
+      resource.discussion.update!( show_on_site: show, locked: lock )
+    elsif show
+      Discussion.create!( resource: @post, show_on_site: show, locked: lock )
+    end
+  end
+end

--- a/app/lib/shiny_post_admin.rb
+++ b/app/lib/shiny_post_admin.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Methods that any admin controller handling ShinyPosts might want
+module ShinyPostAdmin
+  def enforce_change_author_capability_for_create( category )
+    params[ :post ][ :user_id ] = current_user.id unless current_user.can? :change_author, category
+  end
+
+  def enforce_change_author_capability_for_update( category )
+    params[ :post ].delete( :user_id ) unless current_user.can? :change_author, category
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,9 @@ en:
 
     discussion:
       title: Discussion
+      enable_comments: Enable comments
+      show_comments: Show comments
+      lock_comments: Lock comments
 
     emails:
       title: Emails

--- a/plugins/ShinyBlog/app/controllers/shiny_blog/admin/blog_posts_controller.rb
+++ b/plugins/ShinyBlog/app/controllers/shiny_blog/admin/blog_posts_controller.rb
@@ -10,6 +10,7 @@ module ShinyBlog
   # Admin area controller for ShinyBlog plugin for ShinyCMS
   class Admin::BlogPostsController < AdminController
     include ShinyDiscussionAdmin
+    include ShinyPostAdmin
 
     include ShinyDateHelper
     include ShinyPagingHelper
@@ -79,36 +80,26 @@ module ShinyBlog
     end
 
     def strong_params_for_create
+      enforce_change_author_capability_for_create( :blog_posts )
+
       temp_params = params.require( :post ).permit(
         :title, :slug, :body, :tag_list, :show_on_site, :user_id, :posted_at, :posted_at_time
       )
 
-      temp_params = only_admins_can_set_author( temp_params )
-
       combine_date_and_time_params( temp_params, :posted_at )
-    end
-
-    def only_admins_can_set_author( temp_params )
-      temp_params[ :user_id ] = current_user.id unless current_user.can? :change_author, :blog_posts
-      temp_params
     end
 
     def strong_params_for_update
       show, lock = extract_discussion_flags_from_params( params[:post] )
       create_discussion_or_update_flags( @post, show, lock )
 
+      enforce_change_author_capability_for_update( :blog_posts )
+
       temp_params = params.require( :post ).permit(
         :title, :slug, :body, :tag_list, :show_on_site, :user_id, :posted_at, :posted_at_time
       )
 
-      temp_params = only_admins_can_change_author( temp_params )
-
       combine_date_and_time_params( temp_params, :posted_at )
-    end
-
-    def only_admins_can_change_author( temp_params )
-      temp_params.delete( :user_id ) unless current_user.can? :change_author, :blog_posts
-      temp_params
     end
   end
 end

--- a/plugins/ShinyBlog/app/controllers/shiny_blog/admin/blog_posts_controller.rb
+++ b/plugins/ShinyBlog/app/controllers/shiny_blog/admin/blog_posts_controller.rb
@@ -9,6 +9,8 @@
 module ShinyBlog
   # Admin area controller for ShinyBlog plugin for ShinyCMS
   class Admin::BlogPostsController < AdminController
+    include ShinyDiscussionAdmin
+
     include ShinyDateHelper
     include ShinyPagingHelper
 
@@ -68,48 +70,44 @@ module ShinyBlog
       redirect_to blog_posts_path, alert: t( 'shiny_blog.admin.blog_posts.set_post.not_found' )
     end
 
-    def strong_params_for_update
-      temp_params = params.require( :post ).permit(
-        :title, :slug, :body, :tag_list, :show_on_site, :user_id, :posted_at, :posted_at_time,
-        :discussion_show_on_site, :discussion_locked
-      )
-
-      temp_params = combine_date_and_time_inputs( temp_params, :posted_at )
-
-      temp_params.delete( :user_id ) unless current_user.can? :change_author, :blog_posts
-
-      update_discussion_flags( temp_params )
-    end
-
     def set_post_for_create
+      show, lock = extract_discussion_flags_from_params( params[:post] )
+
       @post = Post.new( strong_params_for_create )
+
+      create_discussion_or_update_flags( @post, show, lock ) if show
     end
 
     def strong_params_for_create
       temp_params = params.require( :post ).permit(
-        :title, :slug, :body, :tag_list, :show_on_site, :user_id, :posted_at, :posted_at_time,
-        :discussion_show_on_site, :discussion_locked
+        :title, :slug, :body, :tag_list, :show_on_site, :user_id, :posted_at, :posted_at_time
       )
 
-      temp_params = combine_date_and_time_inputs( temp_params, :posted_at )
+      temp_params = only_admins_can_set_author( temp_params )
 
-      # temp_params = update_discussion_flags( temp_params )
-
-      only_allow_admins_to_set_author( temp_params )
+      combine_date_and_time_params( temp_params, :posted_at )
     end
 
-    def only_allow_admins_to_set_author( temp_params )
+    def only_admins_can_set_author( temp_params )
       temp_params[ :user_id ] = current_user.id unless current_user.can? :change_author, :blog_posts
       temp_params
     end
 
-    def update_discussion_flags( temp_params )
-      show_on_site = temp_params.delete( :discussion_show_on_site ) || 0
-      locked = temp_params.delete( :discussion_locked ) || 0
+    def strong_params_for_update
+      show, lock = extract_discussion_flags_from_params( params[:post] )
+      create_discussion_or_update_flags( @post, show, lock )
 
-      return temp_params if @post.discussion.blank?
+      temp_params = params.require( :post ).permit(
+        :title, :slug, :body, :tag_list, :show_on_site, :user_id, :posted_at, :posted_at_time
+      )
 
-      @post.discussion.update!( show_on_site: show_on_site, locked: locked )
+      temp_params = only_admins_can_change_author( temp_params )
+
+      combine_date_and_time_params( temp_params, :posted_at )
+    end
+
+    def only_admins_can_change_author( temp_params )
+      temp_params.delete( :user_id ) unless current_user.can? :change_author, :blog_posts
       temp_params
     end
   end

--- a/plugins/ShinyBlog/app/views/shiny_blog/admin/blog_posts/edit.html.erb
+++ b/plugins/ShinyBlog/app/views/shiny_blog/admin/blog_posts/edit.html.erb
@@ -35,11 +35,15 @@
     <%= f.check_box :show_on_site %>
   </p>
   <p>
-    <%= f.label :discussion_show_on_site, 'Show comments' %><br>
+    <% if @post.discussion.blank? %>
+    <%= f.label :discussion_show_on_site, t( 'admin.discussion.enable_comments' ) %><br>
+    <% else %>
+    <%= f.label :discussion_show_on_site, t( 'admin.discussion.show_comments' ) %><br>
+    <% end %>
     <%= f.check_box :discussion_show_on_site %>
   </p>
   <p>
-    <%= f.label :discussion_locked, 'Lock comments' %><br>
+    <%= f.label :discussion_locked, t( 'admin.discussion.lock_comments' ) %><br>
     <%= f.check_box :discussion_locked %>
   </p>
 

--- a/plugins/ShinyBlog/app/views/shiny_blog/admin/blog_posts/new.html.erb
+++ b/plugins/ShinyBlog/app/views/shiny_blog/admin/blog_posts/new.html.erb
@@ -34,20 +34,14 @@
     <%= f.label :show_on_site, 'Publish' %><br>
     <%= f.check_box :show_on_site %>
   </p>
-  <!-- TODO: initial state of comment thread
   <p>
-    <%#= f.label :has_comments %><br>
-    <%#= f.check_box :allow_comments %>
-  </p>
-  <p>
-    <%= f.label :discussion_show_on_site, 'Show comments' %><br>
+    <%= f.label :discussion_show_on_site, t( 'admin.discussion.enable_comments' ) %><br>
     <%= f.check_box :discussion_show_on_site %>
   </p>
   <p>
-    <%= f.label :discussion_locked, 'Lock comments' %><br>
+    <%= f.label :discussion_locked, t( 'admin.discussion.lock_comments' ) %><br>
     <%= f.check_box :discussion_locked %>
   </p>
-  -->
 
   <p>
     <%= f.submit t( 'post' ) %>

--- a/plugins/ShinyNews/app/controllers/shiny_news/admin/news_posts_controller.rb
+++ b/plugins/ShinyNews/app/controllers/shiny_news/admin/news_posts_controller.rb
@@ -10,6 +10,7 @@ module ShinyNews
   # Admin area controller for ShinyNews plugin for ShinyCMS
   class Admin::NewsPostsController < AdminController
     include ShinyDiscussionAdmin
+    include ShinyPostAdmin
 
     include ShinyDateHelper
     include ShinyPagingHelper
@@ -79,36 +80,26 @@ module ShinyNews
     end
 
     def strong_params_for_create
+      enforce_change_author_capability_for_create( :news_posts )
+
       temp_params = params.require( :post ).permit(
         :title, :slug, :body, :tag_list, :show_on_site, :user_id, :posted_at, :posted_at_time
       )
 
-      temp_params = only_admins_can_set_author( temp_params )
-
       combine_date_and_time_params( temp_params, :posted_at )
-    end
-
-    def only_admins_can_set_author( temp_params )
-      temp_params[ :user_id ] = current_user.id unless current_user.can? :change_author, :news_posts
-      temp_params
     end
 
     def strong_params_for_update
       show, lock = extract_discussion_flags_from_params( params[:post] )
       create_discussion_or_update_flags( @post, show, lock )
 
+      enforce_change_author_capability_for_update( :news_posts )
+
       temp_params = params.require( :post ).permit(
         :title, :slug, :body, :tag_list, :show_on_site, :user_id, :posted_at, :posted_at_time
       )
 
-      temp_params = only_admins_can_change_author( temp_params )
-
       combine_date_and_time_params( temp_params, :posted_at )
-    end
-
-    def only_admins_can_change_author( temp_params )
-      temp_params.delete( :user_id ) unless current_user.can? :change_author, :blog_posts
-      temp_params
     end
   end
 end

--- a/plugins/ShinyNews/app/views/shiny_news/admin/news_posts/edit.html.erb
+++ b/plugins/ShinyNews/app/views/shiny_news/admin/news_posts/edit.html.erb
@@ -35,11 +35,15 @@
     <%= f.check_box :show_on_site %>
   </p>
   <p>
-    <%= f.label :discussion_show_on_site, 'Show comments' %><br>
+    <% if @post.discussion.blank? %>
+    <%= f.label :discussion_show_on_site, t( 'admin.discussion.enable_comments' ) %><br>
+    <% else %>
+    <%= f.label :discussion_show_on_site, t( 'admin.discussion.show_comments' ) %><br>
+    <% end %>
     <%= f.check_box :discussion_show_on_site %>
   </p>
   <p>
-    <%= f.label :discussion_locked, 'Lock comments' %><br>
+    <%= f.label :discussion_locked, t( 'admin.discussion.lock_comments' ) %><br>
     <%= f.check_box :discussion_locked %>
   </p>
 

--- a/plugins/ShinyNews/app/views/shiny_news/admin/news_posts/new.html.erb
+++ b/plugins/ShinyNews/app/views/shiny_news/admin/news_posts/new.html.erb
@@ -36,20 +36,14 @@
     <%= f.label :show_on_site, 'Publish' %><br>
     <%= f.check_box :show_on_site %>
   </p>
-  <!-- TODO: initial state of comment thread
   <p>
-    <%#= f.label :has_comments %><br>
-    <%#= f.check_box :allow_comments %>
-  </p>
-  <p>
-    <%= f.label :discussion_show_on_site, 'Show comments' %><br>
+    <%= f.label :discussion_show_on_site, t( 'admin.discussion.enable_comments' ) %><br>
     <%= f.check_box :discussion_show_on_site %>
   </p>
   <p>
-    <%= f.label :discussion_locked, 'Lock comments' %><br>
+    <%= f.label :discussion_locked, t( 'admin.discussion.lock_comments' ) %><br>
     <%= f.check_box :discussion_locked %>
   </p>
-  -->
 
   <p>
     <%= f.submit t( 'post' ) %>

--- a/plugins/ShinyNews/spec/requests/admin/news_spec.rb
+++ b/plugins/ShinyNews/spec/requests/admin/news_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe 'Admin::News', type: :request do
           user_id: @admin.id,
           title: Faker::Books::CultureSeries.unique.culture_ship,
           body: Faker::Lorem.paragraph,
-          discussion_show_on_site: true,
-          discussion_locked: true
+          discussion_show_on_site: '1',
+          discussion_locked: '1'
         }
       }
 

--- a/plugins/ShinyNewsletters/app/controllers/shiny_newsletters/admin/sends_controller.rb
+++ b/plugins/ShinyNewsletters/app/controllers/shiny_newsletters/admin/sends_controller.rb
@@ -106,7 +106,7 @@ module ShinyNewsletters
     def strong_params
       temp_params = params.require( :send ).permit( :edition_id, :list_id, :send_at, :send_at_time, :send_now )
 
-      combine_date_and_time_inputs( temp_params, :send_at )
+      combine_date_and_time_params( temp_params, :send_at )
     end
 
     def convert_send_at_to_utc


### PR DESCRIPTION
Discussions weren't getting created when new blog or news posts were created. Now they do. :slightly_smiling_face: 

There's a bunch of refactoring in here to pull some common functionality out into a couple of admin libs, rather than copy-pasting discussion flag handling code into both admin controllers.