### PR TITLE
Use more specific matchers in request specs

### DIFF
--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -119,15 +119,13 @@ namespace :shiny do
 
     def models_to_reorder
       # FIXME: can the plugins provide a load order for their models?
+      # rubocop:disable Layout/MultilineArrayLineBreaks
       %w[
-        ShinyPages::Page
-        ShinyPages::PageElement
-        ShinyNewsletters::Edition
-        ShinyNewsletters::EditionElement
-        ShinyNewsletters::Send
-        Discussion
-        Comment
+        Discussion Comment
+        ShinyPages::Page ShinyPages::PageElement
+        ShinyNewsletters::Edition ShinyNewsletters::EditionElement ShinyNewsletters::Send
       ]
+      # rubocop:enable Layout/MultilineArrayLineBreaks
     end
 
     def remove_models_from_list( model_names )

--- a/plugins/ShinyNewsletters/spec/requests/admin/templates_spec.rb
+++ b/plugins/ShinyNewsletters/spec/requests/admin/templates_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'Admin: Newsletter Templates', type: :request do
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'shiny_newsletters.admin.templates.edit.title' ).titlecase
       expect( response.body ).to have_css '.alert-success', text: I18n.t( 'shiny_newsletters.admin.templates.update.success' )
-      expect( response.body ).to include 'Updated by test'
+      expect( response.body ).to have_field 'template[name]', with: 'Updated by test'
     end
 
     it 'updates the element order' do

--- a/plugins/ShinyPages/spec/requests/admin/templates_spec.rb
+++ b/plugins/ShinyPages/spec/requests/admin/templates_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'Admin: Page Templates', type: :request do
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title I18n.t( 'shiny_pages.admin.templates.edit.title' ).titlecase
       expect( response.body ).to have_css '.alert-success', text: I18n.t( 'shiny_pages.admin.templates.update.success' )
-      expect( response.body ).to include 'Updated by test'
+      expect( response.body ).to have_field 'template[name]', with: 'Updated by test'
     end
 
     it 'updates the element order' do

--- a/plugins/ShinySearch/spec/requests/search_spec.rb
+++ b/plugins/ShinySearch/spec/requests/search_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Search:', type: :request do
+  before :each do
+    @user = create :user, public_name: 'Success'
+  end
+
   describe 'GET /search' do
     it 'displays the search form' do
       get shiny_search.search_path
@@ -14,13 +18,11 @@ RSpec.describe 'Search:', type: :request do
 
   describe 'GET /search?query=Success' do
     it 'displays the search results using the default search back-end (pg_search)' do
-      user = create :user, public_name: 'Success'
-
       get shiny_search.search_path, params: { query: 'Success' }
 
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'shiny_search.search.results.title', query: 'Success' )
-      expect( response.body ).to     have_link user.public_name, href: "/profile/#{user.username}"
+      expect( response.body ).to     have_link @user.name, href: shiny_profiles.profile_path( @user.username )
       expect( response.body ).not_to have_css 'p', text: I18n.t( 'shiny_search.search.no_results.no_results' )
     end
 
@@ -42,41 +44,35 @@ RSpec.describe 'Search:', type: :request do
 
   describe 'GET /search?engine=pg&query=Success' do
     it 'displays the search results, explicitly using the pg_search back-end' do
-      user = create :user, public_name: 'Success'
-
       get shiny_search.search_path, params: { engine: 'pg', query: 'Success' }
 
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'shiny_search.search.results.title', query: 'Success' )
-      expect( response.body ).to     have_link user.public_name, href: "/profile/#{user.username}"
+      expect( response.body ).to     have_link @user.name, href: shiny_profiles.profile_path( @user.username )
       expect( response.body ).not_to have_css 'p', text: I18n.t( 'shiny_search.search.no_results.no_results' )
     end
   end
 
   describe 'GET /search?engine=algolia&query=Success' do
     it 'displays the search results, using the Algolia search back-end' do
-      # user = create :user, public_name: 'Success'
-
       get shiny_search.search_path, params: { engine: 'algolia', query: 'Success' }
 
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'shiny_search.search.results.title', query: 'Success' )
       # TODO
-      # expect( response.body ).to     have_link user.public_name, href: "/profile/#{user.username}"
+      # expect( response.body ).to     have_link @user.name, href: shiny_profiles.profile_path( @user.username )
       # expect( response.body ).not_to have_css 'p', text: I18n.t( 'shiny_search.search.no_results.no_results' )
     end
   end
 
   describe 'GET /search?query=FAIL' do
     it 'displays the lack of search results' do
-      user = create :user, public_name: 'Success'
-
       get "#{shiny_search.search_path}?query=FAIL"
 
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'shiny_search.search.results.title', query: 'FAIL' )
       expect( response.body ).to     have_css 'p', text: I18n.t( 'shiny_search.search.no_results.no_results' )
-      expect( response.body ).not_to include "/profile/#{user.username}"
+      expect( response.body ).not_to have_link @user.name, href: shiny_profiles.profile_path( @user.username )
     end
   end
 end

--- a/spec/requests/admin/comments_spec.rb
+++ b/spec/requests/admin/comments_spec.rb
@@ -82,9 +82,11 @@ RSpec.describe Admin::CommentsController, type: :request do
       expect( @comment2.reload.spam? ).to be true
 
       put comments_path, params: {
-        'spam_comments[spam_or_ham]': 'spam',
-        "spam_comments[comment_#{@nested1.id}]": 1,
-        "spam_comments[comment_#{@comment2.id}]": 0
+        spam_comments: {
+          spam_or_ham: 'spam',
+          "comment_#{@nested1.id}": 1,
+          "comment_#{@comment2.id}": 0
+        }
       }
 
       expect( response      ).to     have_http_status :found
@@ -109,9 +111,11 @@ RSpec.describe Admin::CommentsController, type: :request do
       expect( @comment2.reload.spam? ).to be true
 
       put comments_path, params: {
-        'spam_comments[spam_or_ham]': 'ham',
-        "spam_comments[comment_#{@nested1.id}]": 1,
-        "spam_comments[comment_#{@comment2.id}]": 0
+        spam_comments: {
+          spam_or_ham: 'ham',
+          "comment_#{@nested1.id}": 1,
+          "comment_#{@comment2.id}": 0
+        }
       }
 
       expect( response      ).to     have_http_status :found
@@ -136,9 +140,11 @@ RSpec.describe Admin::CommentsController, type: :request do
       @comment2.mark_as_spam
 
       put comments_path, params: {
-        'spam_comments[spam_or_ham]': 'ham',
-        "spam_comments[comment_#{@nested1.id}]": 1,
-        "spam_comments[comment_#{@comment2.id}]": 0
+        spam_comments: {
+          spam_or_ham: 'ham',
+          "comment_#{@nested1.id}": 1,
+          "comment_#{@comment2.id}": 0
+        }
       }
 
       expect( response      ).to have_http_status :found
@@ -232,7 +238,7 @@ RSpec.describe Admin::CommentsController, type: :request do
       expect( response      ).to redirect_to @news.path( anchor: 'comments' )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).not_to include @comment2.title
+      expect( response.body ).not_to have_css 'td', text: @comment2.title
     end
   end
 end


### PR DESCRIPTION
Fixing a few of the (but not all) of the include matchers mentioned in issue 158 