### PR TITLE
Email recipients admin page

### DIFF
--- a/app/controllers/admin/email_previews_controller.rb
+++ b/app/controllers/admin/email_previews_controller.rb
@@ -8,5 +8,5 @@
 
 # Base controller for Rails Email Preview, used by /admin/emails
 class Admin::EmailPreviewsController < AdminController
-  before_action -> { authorize :email_preview }, only: %i[ index show ]
+  before_action -> { authorize :mailer_preview }, only: %i[ index show ]
 end

--- a/app/controllers/admin/email_recipients_controller.rb
+++ b/app/controllers/admin/email_recipients_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Controller for main site email-recipient features in ShinyCMS
+class Admin::EmailRecipientsController < AdminController
+  include ShinyPagingHelper
+
+  def index
+    authorize EmailRecipient
+
+    @recipients = EmailRecipient.page( page_number ).per( items_per_page )
+    authorize @recipients
+  end
+
+  def search
+    authorize EmailRecipient
+
+    q = params[:q]
+    @recipients = EmailRecipient.where( 'email ilike ?', "%#{q}%" )
+                                .or( EmailRecipient.where( 'name ilike ?', "%#{q}%" ) )
+                                .order( updated_at: :desc )
+                                .page( page_number ).per( items_per_page )
+
+    authorize @recipients if @recipients.present?
+    render :index
+  end
+
+  def do_not_contact
+    authorize EmailRecipient
+
+    recipient = EmailRecipient.find( param[ :id ] )
+    authorize recipient
+
+    flash[ :notice ] = t( '.success' ) if recipient && DoNotContact.add( recipient.email )
+
+    redirect_to email_recipients_path
+  end
+
+  def destroy
+    authorize EmailRecipient
+
+    recipient = EmailRecipient.find( param[ :id ] )
+    authorize recipient
+
+    flash[ :notice ] = t( '.success' ) if recipient.destroy
+
+    redirect_to email_recipients_path
+  end
+end

--- a/app/controllers/admin/email_recipients_controller.rb
+++ b/app/controllers/admin/email_recipients_controller.rb
@@ -12,7 +12,6 @@ class Admin::EmailRecipientsController < AdminController
 
   def index
     authorize EmailRecipient
-
     @recipients = EmailRecipient.page( page_number ).per( items_per_page )
     authorize @recipients
   end
@@ -32,8 +31,7 @@ class Admin::EmailRecipientsController < AdminController
 
   def do_not_contact
     authorize EmailRecipient
-
-    recipient = EmailRecipient.find( param[ :id ] )
+    recipient = EmailRecipient.find( params[ :id ] )
     authorize recipient
 
     flash[ :notice ] = t( '.success' ) if recipient && DoNotContact.add( recipient.email )
@@ -43,8 +41,7 @@ class Admin::EmailRecipientsController < AdminController
 
   def destroy
     authorize EmailRecipient
-
-    recipient = EmailRecipient.find( param[ :id ] )
+    recipient = EmailRecipient.find( params[ :id ] )
     authorize recipient
 
     flash[ :notice ] = t( '.success' ) if recipient.destroy

--- a/app/models/email_recipient.rb
+++ b/app/models/email_recipient.rb
@@ -11,6 +11,7 @@
 class EmailRecipient < ApplicationRecord
   include ShinyDemoDataProvider
   include ShinyEmail
+  include ShinyPaging
   include ShinySoftDelete
   include ShinyToken
 

--- a/app/policies/ahoy/message_policy.rb
+++ b/app/policies/ahoy/message_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for email stats (powered by Ahoy::Email)
 class Ahoy::MessagePolicy
   attr_reader :this_user, :record

--- a/app/policies/ahoy/visit_policy.rb
+++ b/app/policies/ahoy/visit_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for web stats (powered by Ahoy)
 class Ahoy::VisitPolicy
   attr_reader :this_user, :record

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for comment moderation and spam comment admin
 class CommentPolicy
   attr_reader :this_user, :record

--- a/app/policies/consent_version_policy.rb
+++ b/app/policies/consent_version_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for users
 class ConsentVersionPolicy
   attr_reader :this_user, :record

--- a/app/policies/discussion_policy.rb
+++ b/app/policies/discussion_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for administration of discussions
 class DiscussionPolicy
   attr_reader :this_user, :record

--- a/app/policies/email_recipient_policy.rb
+++ b/app/policies/email_recipient_policy.rb
@@ -24,14 +24,6 @@ class EmailRecipientPolicy
     index?
   end
 
-  def edit?
-    @this_user.can? :edit, :email_recipients
-  end
-
-  def update?
-    edit?
-  end
-
   def do_not_contact?
     destroy?
   end

--- a/app/policies/email_recipient_policy.rb
+++ b/app/policies/email_recipient_policy.rb
@@ -32,6 +32,10 @@ class EmailRecipientPolicy
     edit?
   end
 
+  def do_not_contact?
+    destroy?
+  end
+
   def destroy?
     @this_user.can? :destroy, :email_recipients
   end

--- a/app/policies/email_recipient_policy.rb
+++ b/app/policies/email_recipient_policy.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Pundit policy for email recipients
+# (people that we send email to, who don't have a user account - comment notifications, list subscribers, etc)
+class EmailRecipientPolicy
+  attr_reader :this_user, :record
+
+  def initialize( this_user, record )
+    @this_user = this_user
+    @record = record
+  end
+
+  def index?
+    @this_user.can? :list, :email_recipients
+  end
+
+  def search?
+    index?
+  end
+
+  def edit?
+    @this_user.can? :edit, :email_recipients
+  end
+
+  def update?
+    edit?
+  end
+
+  def destroy?
+    @this_user.can? :destroy, :email_recipients
+  end
+end

--- a/app/policies/feature_flag_policy.rb
+++ b/app/policies/feature_flag_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for feature flag administration
 class FeatureFlagPolicy
   attr_reader :this_user, :record

--- a/app/policies/mailer_preview_policy.rb
+++ b/app/policies/mailer_preview_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for mailer previews
 class MailerPreviewPolicy
   attr_reader :this_user, :record

--- a/app/policies/mailer_preview_policy.rb
+++ b/app/policies/mailer_preview_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Pundit policy for email previews
-class EmailPreviewPolicy
+# Pundit policy for mailer previews
+class MailerPreviewPolicy
   attr_reader :this_user, :record
 
   def initialize( this_user, record )
@@ -10,10 +10,10 @@ class EmailPreviewPolicy
   end
 
   def index?
-    @this_user.can? :list, :email_previews
+    @this_user.can? :list, :mailer_previews
   end
 
   def show?
-    @this_user.can? :show, :email_previews
+    @this_user.can? :show, :mailer_previews
   end
 end

--- a/app/policies/setting_policy.rb
+++ b/app/policies/setting_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for settings admin area
 class SettingPolicy
   attr_reader :this_user, :record

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Pundit policy for users
 class UserPolicy
   attr_reader :this_user, :record

--- a/app/views/admin/email_recipients/index.html.erb
+++ b/app/views/admin/email_recipients/index.html.erb
@@ -30,7 +30,11 @@
         <%= recipient.name %>
       </td>
       <td>
-        <%= recipient.status %>
+        <% if recipient.confirmed? %>
+          <%= t( '.confirmed' ) %>
+        <% else %>
+          <%= t( '.unconfirmed' ) %>
+        <% end %>
       </td>
       <td class="actions">
         <%= link_to t( 'delete' ), main_app.email_recipients_path( recipient ),

--- a/app/views/admin/email_recipients/index.html.erb
+++ b/app/views/admin/email_recipients/index.html.erb
@@ -1,0 +1,44 @@
+<% @page_title = t( '.title' ) %>
+
+<%= render partial: 'admin/includes/search', locals: { placeholder: t( '.search' ) } %>
+
+<table class="table table-responsive-sm table-striped">
+  <thead>
+    <tr>
+      <th>
+        Email
+      </th>
+      <th>
+        Name
+      </th>
+      <th>
+        Status
+      </th>
+      <th>
+        &nbsp;
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @recipients.each do |recipient| %>
+    <tr>
+      <td>
+        <%= recipient.email %>
+      </td>
+      <td>
+        <%= recipient.name %>
+      </td>
+      <td>
+        <%= recipient.status %>
+      </td>
+      <td class="actions">
+        <%= link_to t( 'delete' ), main_app.email_recipients_path( recipient ),
+            method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
+      </td>
+    </tr>
+    <% end %>
+  <tbody>
+</table>
+
+<%= render partial: 'admin/includes/pager', locals: { paged: @recipients } %>

--- a/app/views/admin/email_recipients/index.html.erb
+++ b/app/views/admin/email_recipients/index.html.erb
@@ -37,7 +37,8 @@
         <% end %>
       </td>
       <td class="actions">
-        <%= link_to t( 'delete' ), main_app.email_recipients_path( recipient ),
+        <%= link_to t( '.do_not_contact' ), main_app.do_not_contact_email_recipient_path( recipient ), method: :put %>
+        <%= link_to t( 'delete' ), main_app.email_recipient_path( recipient ),
             method: :delete, data: { confirm: t( 'are_you_sure' ) } %>
       </td>
     </tr>

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -14,10 +14,12 @@
       <% elsif plugin_loaded? plugin_name %>
         <%= link_to *plugin_breadcrumb_link_text_and_path( plugin_name, controller_name ) %>
 
-      <%# Blazer %>
+      <%# Other engines %>
       <% elsif plugin_name == 'Blazer' %>
         <% @page_title = controller_name.titlecase %> <%# TODO: i18n %>
         <%= link_to t( 'admin.stats.breadcrumb' ), blazer.root_path %>
+      <% elsif plugin_name == 'RailsEmailPreview' %>
+        <%= link_to t( 'rails_email_preview.breadcrumb' ), rails_email_preview.rep_root_path %>
 
       <%# ShinyCMS core features %>
       <% else %>

--- a/app/views/admin/menu/_menu.html.erb
+++ b/app/views/admin/menu/_menu.html.erb
@@ -5,6 +5,8 @@
 
   <%= render partial: 'admin/menu/menu_users' %>
 
+  <%= render partial: 'admin/menu/menu_email' %>
+
   <%= render partial: 'admin/menu/menu_other' %>
 
   <%= render partial: 'admin/menu/menu_stats' %>

--- a/app/views/admin/menu/_menu_email.html.erb
+++ b/app/views/admin/menu/_menu_email.html.erb
@@ -1,0 +1,9 @@
+  <%= render_admin_menu_section( t( 'admin.email.menu' ), 'envelope-open' ) do %>
+
+    <%= render_admin_menu_item_if( current_user.can?( :list, :email_recipients ),
+        t( 'admin.email_recipients.menu' ), main_app.email_recipients_path, 'envelope-closed' ) %>
+
+    <%= render_admin_menu_item_if( current_user.can?( :list, :mailer_previews ),
+        t( 'admin.mailer_previews.menu' ), rails_email_preview_path, 'envelope-letter' ) %>
+
+  <% end %>

--- a/app/views/admin/menu/_menu_email.html.erb
+++ b/app/views/admin/menu/_menu_email.html.erb
@@ -4,6 +4,6 @@
         t( 'admin.email_recipients.menu' ), main_app.email_recipients_path, 'envelope-closed' ) %>
 
     <%= render_admin_menu_item_if( current_user.can?( :list, :mailer_previews ),
-        t( 'admin.mailer_previews.menu' ), rails_email_preview_path, 'envelope-letter' ) %>
+        t( 'rails_email_preview.menu' ), rails_email_preview_path, 'envelope-letter' ) %>
 
   <% end %>

--- a/app/views/admin/menu/_menu_other.html.erb
+++ b/app/views/admin/menu/_menu_other.html.erb
@@ -7,7 +7,7 @@
     <%= render_admin_menu_item_if( current_user.can?( :list, :spam_comments ),
         t( 'admin.comments.menu' ), comments_path, 'trash' ) %>
 
-    <%= render_admin_menu_item_if( current_user.can?( :list, :email_previews ),
-        t( 'admin.emails.menu' ), rails_email_preview_path, 'envelope-letter' ) %>
+    <%= render_admin_menu_item_if( current_user.can?( :list, :mailer_previews ),
+        t( 'admin.mailer_previews.menu' ), rails_email_preview_path, 'envelope-letter' ) %>
 
   <% end %>

--- a/app/views/admin/menu/_menu_other.html.erb
+++ b/app/views/admin/menu/_menu_other.html.erb
@@ -7,7 +7,4 @@
     <%= render_admin_menu_item_if( current_user.can?( :list, :spam_comments ),
         t( 'admin.comments.menu' ), comments_path, 'trash' ) %>
 
-    <%= render_admin_menu_item_if( current_user.can?( :list, :mailer_previews ),
-        t( 'admin.mailer_previews.menu' ), rails_email_preview_path, 'envelope-letter' ) %>
-
   <% end %>

--- a/app/views/shinycms/user_mailer/confirmation_instructions.text.erb
+++ b/app/views/shinycms/user_mailer/confirmation_instructions.text.erb
@@ -1,4 +1,4 @@
-<%= t( 'user_mailer.welcome', name: @resource.username ) %>,
+<%= t( 'user_mailer.welcome', name: @resource.username ) %>
 
 <%= t( '.instructions' ) %>:
 

--- a/app/views/shinycms/user_mailer/email_changed_instructions.html.mjml
+++ b/app/views/shinycms/user_mailer/email_changed_instructions.html.mjml
@@ -16,7 +16,7 @@
   <mj-column>
     <mj-text align="left" color="#797e82" font-family="Open Sans, Helvetica, Arial, sans-serif" font-size="13px" line-height="22px" padding-bottom="0px" padding-left="50px" padding-right="50px" padding-top="0px" padding="0px 25px 0px 25px">
       <h2 style="text-align:center; color: #000000; line-height:32px">
-        <%= t( 'user_mailer.hello', name: @resource.username ) %>,
+        <%= t( 'user_mailer.hello', name: @resource.username ) %>
       </h2>
     </mj-text>
     <mj-text align="left" color="#797e82" font-family="Open Sans, Helvetica, Arial, sans-serif" font-size="13px" line-height="22px" padding-bottom="0px" padding-left="50px" padding-right="50px" padding-top="0px" padding="0px 25px 0px 25px">

--- a/app/views/shinycms/user_mailer/email_changed_instructions.text.erb
+++ b/app/views/shinycms/user_mailer/email_changed_instructions.text.erb
@@ -1,4 +1,4 @@
-<%= t( 'user_mailer.hello', name: @resource.username ) %>,
+<%= t( 'user_mailer.hello', name: @resource.username ) %>
 
 <% if @resource.try( :unconfirmed_email? ) %>
   <%= t( '.email_changing' ) %>:

--- a/app/views/shinycms/user_mailer/password_changed_instructions.html.mjml
+++ b/app/views/shinycms/user_mailer/password_changed_instructions.html.mjml
@@ -16,7 +16,7 @@
   <mj-column>
     <mj-text align="left" color="#797e82" font-family="Open Sans, Helvetica, Arial, sans-serif" font-size="13px" line-height="22px" padding-bottom="0px" padding-left="50px" padding-right="50px" padding-top="0px" padding="0px 25px 0px 25px">
       <h2 style="text-align:center; color: #000000; line-height:32px">
-        <%= t( 'user_mailer.hello', name: @resource.username ) %>,
+        <%= t( 'user_mailer.hello', name: @resource.username ) %>
       </h2>
     </mj-text>
     <mj-text align="left" color="#797e82" font-family="Open Sans, Helvetica, Arial, sans-serif" font-size="13px" line-height="22px" padding-bottom="0px" padding-left="50px" padding-right="50px" padding-top="0px" padding="0px 25px 0px 25px">

--- a/app/views/shinycms/user_mailer/password_changed_instructions.text.erb
+++ b/app/views/shinycms/user_mailer/password_changed_instructions.text.erb
@@ -1,3 +1,3 @@
-<%= t( 'user_mailer.hello', name: @resource.username ) %>,
+<%= t( 'user_mailer.hello', name: @resource.username ) %>
 
 <%= t( '.text' ) %>

--- a/app/views/shinycms/user_mailer/reset_password_instructions.html.mjml
+++ b/app/views/shinycms/user_mailer/reset_password_instructions.html.mjml
@@ -16,7 +16,7 @@
   <mj-column>
     <mj-text align="left" color="#797e82" font-family="Open Sans, Helvetica, Arial, sans-serif" font-size="13px" line-height="22px" padding-bottom="0px" padding-left="50px" padding-right="50px" padding-top="0px" padding="0px 25px 0px 25px">
       <h2 style="text-align:center; color: #000000; line-height:32px">
-        <%= t( 'user_mailer.hello', name: @resource.username ) %>,
+        <%= t( 'user_mailer.hello', name: @resource.username ) %>
       </h2>
     </mj-text>
     <mj-text align="left" color="#797e82" font-family="Open Sans, Helvetica, Arial, sans-serif" font-size="13px" line-height="22px" padding-bottom="0px" padding-left="50px" padding-right="50px" padding-top="0px" padding="0px 25px 0px 25px">

--- a/app/views/shinycms/user_mailer/reset_password_instructions.text.erb
+++ b/app/views/shinycms/user_mailer/reset_password_instructions.text.erb
@@ -1,4 +1,4 @@
-<%= t( 'user_mailer.hello', name: @resource.username ) %>,
+<%= t( 'user_mailer.hello', name: @resource.username ) %>
 
 <%= t( '.instructions' ) %>:
 

--- a/app/views/shinycms/user_mailer/unlock_instructions.html.mjml
+++ b/app/views/shinycms/user_mailer/unlock_instructions.html.mjml
@@ -16,7 +16,7 @@
   <mj-column>
     <mj-text align="left" color="#797e82" font-family="Open Sans, Helvetica, Arial, sans-serif" font-size="13px" line-height="22px" padding-bottom="0px" padding-left="50px" padding-right="50px" padding-top="0px" padding="0px 25px 0px 25px">
       <h2 style="text-align:center; color: #000000; line-height:32px">
-        <%= t( 'user_mailer.hello', name: @resource.username ) %>,
+        <%= t( 'user_mailer.hello', name: @resource.username ) %>
       </h2>
     </mj-text>
     <mj-text align="left" color="#797e82" font-family="Open Sans, Helvetica, Arial, sans-serif" font-size="13px" line-height="22px" padding-bottom="0px" padding-left="50px" padding-right="50px" padding-top="0px" padding="0px 25px 0px 25px">

--- a/app/views/shinycms/user_mailer/unlock_instructions.text.erb
+++ b/app/views/shinycms/user_mailer/unlock_instructions.text.erb
@@ -1,4 +1,4 @@
-<%= t( 'user_mailer.hello', name: @resource.username ) %>,
+<%= t( 'user_mailer.hello', name: @resource.username ) %>
 
 <%= t( '.explanation' ) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,10 +380,6 @@ en:
       show_comments: Show comments
       lock_comments: Lock comments
 
-    emails:
-      breadcrumb: Emails
-      menu: Emails
-
     email_stats:
       breadcrumb: Stats
       menu: Email stats
@@ -406,6 +402,10 @@ en:
         failure: Failed to update feature flags
 
     letter_opener_web: Outbox
+
+    mailer_previews:
+      breadcrumb: Mailers
+      menu: Mailer previews
 
     other:
       menu: Other

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,6 +390,8 @@ en:
       index:
         title: Manage email recipients
         search: Search email recipients
+        confirmed: Confirmed
+        unconfirmed: Not Confirmed
       do_not_contact:
         success: Email recipient deleted, email address added to Do Not Contact list
       destroy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,6 +380,16 @@ en:
       show_comments: Show comments
       lock_comments: Lock comments
 
+    email:
+      menu: Email
+
+    email_recipients:
+      breadcrumb: Email Recipients
+      menu: Email recipients
+      index:
+        title: Manage email recipients
+        search: Search email recipients
+
     email_stats:
       breadcrumb: Stats
       menu: Email stats

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,13 +302,14 @@ en:
   # ==================== ( Admin Area ) ==============================
 
   rails_email_preview:
+    breadcrumb: Mailers
+    menu: Mailer previews
     emails:
       index:
         title: All mailers
       show:
         title: Preview email
         breadcrumb_list: Emails
-
   rep:
     base:
       email:
@@ -389,6 +390,10 @@ en:
       index:
         title: Manage email recipients
         search: Search email recipients
+      do_not_contact:
+        success: Email recipient deleted, email address added to Do Not Contact list
+      destroy:
+        success: Email recipient deleted
 
     email_stats:
       breadcrumb: Stats
@@ -412,10 +417,6 @@ en:
         failure: Failed to update feature flags
 
     letter_opener_web: Outbox
-
-    mailer_previews:
-      breadcrumb: Mailers
-      menu: Mailer previews
 
     other:
       menu: Other

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,8 +392,9 @@ en:
         search: Search email recipients
         confirmed: Confirmed
         unconfirmed: Not Confirmed
+        do_not_contact: Do Not Contact
       do_not_contact:
-        success: Email recipient deleted, email address added to Do Not Contact list
+        success: Email address added to Do Not Contact list
       destroy:
         success: Email recipient deleted
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
       # Consent versions
       resources :consent_versions, path: 'consent-versions', concerns: %i[ paginatable searchable ]
 
-      # Discussion and comment moderation
+      # Comment and discussion moderation
       get 'comments(/page/:page)', to: 'comments#index', as: :comments
       put 'comments',              to: 'comments#update'
       get 'comments/search',       to: 'comments#search'
@@ -91,6 +91,12 @@ Rails.application.routes.draw do
         put ':id/hide',   to: 'discussions#hide',   as: :hide_discussion
         put ':id/lock',   to: 'discussions#lock',   as: :lock_discussion
         put ':id/unlock', to: 'discussions#unlock', as: :unlock_discussion
+      end
+
+      # Email Recipients
+      resources :email_recipients, path: 'email-recipients', concerns: %i[ paginatable searchable ],
+                                   except: %i[ show new create ] do
+        put :'do-not-contact', on: :member, to: 'email_recipients#do_not_contact'
       end
 
       # Feature Flags

--- a/db/seeds/capabilities.rb
+++ b/db/seeds/capabilities.rb
@@ -25,7 +25,7 @@ add_capabilities(
     discussions:      %w[ show hide lock unlock ],
     comments:         %w[ show hide lock unlock destroy ],
     spam_comments:    %w[ list add destroy ],
-    email_previews:   %w[ list show ],
+    mailer_previews:  %w[ list show ],
     stats:            %w[ view_web view_email view_charts make_charts ],
     feature_flags:    %w[ list edit ],
     settings:         %w[ list edit ],

--- a/db/seeds/capabilities.rb
+++ b/db/seeds/capabilities.rb
@@ -25,6 +25,7 @@ add_capabilities(
     discussions:      %w[ show hide lock unlock ],
     comments:         %w[ show hide lock unlock destroy ],
     spam_comments:    %w[ list add destroy ],
+    email_recipients: %w[ list edit destroy ],
     mailer_previews:  %w[ list show ],
     stats:            %w[ view_web view_email view_charts make_charts ],
     feature_flags:    %w[ list edit ],

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -140,6 +140,14 @@
 * Replace hand-rolled trees and recursion (page sections, etc) with ClosureTree ?
     * https://github.com/ClosureTree/closure_tree
 
+* Wiki?
+    * Integrate an existing project? https://www.ruby-toolbox.com/categories/wiki_apps
+
+* Integrate a static site generator? https://www.ruby-toolbox.com/categories/static_website_generation
+
+* Run multiple ShinySites from one ShinyCMS installation?
+    * https://www.ruby-toolbox.com/categories/Multitenancy
+
 
 ## Done / In Progress
 

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -15,6 +15,8 @@
     * https://ckeditor.com/docs/ckeditor5/latest/Features/MainApp/image-upload/ckfinder.html
     * Integrate functionality from MahBucket here?
 
+* Mock/VCR the Akismet tests (and anything else that currently needs a 'net connection)
+
 * Site map
     * https://github.com/kjvarga/sitemap_generator ?
 

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -4,8 +4,6 @@
 
 ### Urgent / Important
 
-* ShinyForms needs bot protection like whoa. :(
-
 * Heroku Scheduler / Cron / Whenever / whatever for running scheduled Newsletter Send jobs
 
 
@@ -55,8 +53,6 @@
 * Make a generic sidebar template that renders any partials in a specified directory
 
 * Re-assess use of helpers (vs models/libs/whatever) for Akismet and reCaptcha (and others?)
-
-* Add an admin UI for viewing/managing EmailRecipients
 
 * Allow an EmailRecipient to reset their token (in case they forward an email containing it to somebody else)
 

--- a/docs/Developers/in-progress.md
+++ b/docs/Developers/in-progress.md
@@ -29,6 +29,7 @@ Features that I'm halfway through implementing (with notes on where I'm up to, w
         * Move each plugin into its own separate gem
             * Move pages, newsletters, and forms test templates into each plugin's spec/fixtures
             * Look at Combustion, for minimal test apps for gems: https://github.com/pat/combustion
+            * List ShinyBlog on https://www.ruby-toolbox.com/categories/Blog_Engines
 
 * Blazer dashboards / charts / etc: https://github.com/ankane/blazer
     * This is merged, but needs a default dashboard and queries setting up

--- a/docs/Developers/in-progress.md
+++ b/docs/Developers/in-progress.md
@@ -17,6 +17,8 @@ Features that I'm halfway through implementing (with notes on where I'm up to, w
 
 ### Features that don't exist in the Perl version but I seem to be working on them anyway
 
+* Admin UI for viewing/managing EmailRecipients
+
 * Plugin architecture
     * I've converted most of the existing features into Rails Engine plugins
     * Still to do:

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -84,6 +84,20 @@ FactoryBot.define do
     end
   end
 
+  factory :email_recipient_admin, parent: :admin_user do
+    after :create do |admin|
+      category = CapabilityCategory.find_by( name: 'email_recipients' )
+
+      list    = category.capabilities.find_by( name: 'list'    )
+      edit    = category.capabilities.find_by( name: 'edit'    )
+      destroy = category.capabilities.find_by( name: 'destroy' )
+
+      create :user_capability, user: admin, capability: list
+      create :user_capability, user: admin, capability: edit
+      create :user_capability, user: admin, capability: destroy
+    end
+  end
+
   factory :mailer_admin, parent: :admin_user do
     after :create do |admin|
       category = CapabilityCategory.find_by( name: 'mailer_previews' )

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -84,9 +84,9 @@ FactoryBot.define do
     end
   end
 
-  factory :email_admin, parent: :admin_user do
+  factory :mailer_admin, parent: :admin_user do
     after :create do |admin|
-      category = CapabilityCategory.find_by( name: 'email_previews' )
+      category = CapabilityCategory.find_by( name: 'mailer_previews' )
 
       list = category.capabilities.find_by( name: 'list' )
       show = category.capabilities.find_by( name: 'show' )

--- a/spec/mailer_previews/discussion_mailer_preview_spec.rb
+++ b/spec/mailer_previews/discussion_mailer_preview_spec.rb
@@ -11,7 +11,7 @@ require 'rails_helper'
 # Tests for discussion mailer previews (powered by RailsEmailPreview)
 RSpec.describe 'DiscussionMailerPreview', type: :request do
   before :each do
-    admin = create :email_admin
+    admin = create :mailer_admin
     sign_in admin
 
     u = create :user

--- a/spec/mailer_previews/rails_email_preview_spec.rb
+++ b/spec/mailer_previews/rails_email_preview_spec.rb
@@ -11,7 +11,7 @@ require 'rails_helper'
 # Tests for the RailsEmailPreview engine, which powers admin previews of site emails
 RSpec.describe RailsEmailPreview, type: :request do
   before :each do
-    admin = create :email_admin
+    admin = create :mailer_admin
     sign_in admin
   end
 

--- a/spec/mailer_previews/user_mailer_preview_spec.rb
+++ b/spec/mailer_previews/user_mailer_preview_spec.rb
@@ -11,7 +11,7 @@ require 'rails_helper'
 # Tests for previewing the user mailer (powered by RailsEmailPreview)
 RSpec.describe UserMailerPreview, type: :request do
   before :each do
-    admin = create :email_admin
+    admin = create :mailer_admin
     sign_in admin
 
     @site_name = ::Setting.get( :site_name ) || I18n.t( 'site_name' )

--- a/spec/requests/admin/email_recipients_spec.rb
+++ b/spec/requests/admin/email_recipients_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Admin::EmailRecipientsController, type: :request do
       follow_redirect!
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'admin.email_recipients.index.title' ).titlecase
-      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.email_recipients.destroy.success' )
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.email_recipients.do_not_contact.success' )
       expect( response.body ).to     have_css 'td', text: recipient1.name
 
       expect( DoNotContact.include?( email1 ) ).to be true

--- a/spec/requests/admin/email_recipients_spec.rb
+++ b/spec/requests/admin/email_recipients_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+require 'rails_helper'
+
+# Tests for email recipient admin features
+RSpec.describe Admin::EmailRecipientsController, type: :request do
+  before :each do
+    admin = create :email_recipient_admin
+    sign_in admin
+  end
+
+  describe 'GET /admin/email-recipients' do
+    it 'fetches the list of email recipients' do
+      recipient1 = create :email_recipient
+      create :email_recipient
+      create :email_recipient
+
+      get email_recipients_path
+
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_title I18n.t( 'admin.email_recipients.index.title' ).titlecase
+      expect( response.body ).to have_css 'td', text: recipient1.name
+    end
+  end
+
+  describe 'GET /admin/email-recipients/search?q=movie' do
+    it 'fetches the list of matching consent versions' do
+      recipient1 = create :email_recipient, name: 'Awesome Alice'
+      recipient2 = create :email_recipient, name: 'B-movie Bob'
+
+      get search_email_recipients_path, params: { q: 'movie' }
+
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_title I18n.t( 'admin.email_recipients.index.title' ).titlecase
+
+      expect( response.body ).to     have_css 'td', text: recipient2.name
+      expect( response.body ).not_to have_css 'td', text: recipient1.name
+    end
+  end
+
+  describe 'DELETE /admin/email-recipients/:id/do-not-contact' do
+    it 'adds the specified email recipient to the Do Not Contact list' do
+      recipient1 = create :email_recipient
+
+      email1 = recipient1.email
+
+      put do_not_contact_email_recipient_path( recipient1 )
+
+      expect( response      ).to     have_http_status :found
+      expect( response      ).to     redirect_to email_recipients_path
+      follow_redirect!
+      expect( response      ).to     have_http_status :ok
+      expect( response.body ).to     have_title I18n.t( 'admin.email_recipients.index.title' ).titlecase
+      expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.email_recipients.destroy.success' )
+      expect( response.body ).to     have_css 'td', text: recipient1.name
+
+      expect( DoNotContact.include?( email1 ) ).to be true
+    end
+
+    describe 'DELETE /admin/email-recipients/:id' do
+      it 'deletes the specified email recipient' do
+        recipient1 = create :email_recipient
+        recipient2 = create :email_recipient
+        recipient3 = create :email_recipient
+
+        delete email_recipient_path( recipient2 )
+
+        expect( response      ).to     have_http_status :found
+        expect( response      ).to     redirect_to email_recipients_path
+        follow_redirect!
+        expect( response      ).to     have_http_status :ok
+        expect( response.body ).to     have_title I18n.t( 'admin.email_recipients.index.title' ).titlecase
+        expect( response.body ).to     have_css '.alert-success', text: I18n.t( 'admin.email_recipients.destroy.success' )
+        expect( response.body ).to     have_css 'td', text: recipient1.name
+        expect( response.body ).not_to have_css 'td', text: recipient2.name
+        expect( response.body ).to     have_css 'td', text: recipient3.name
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds page allowing admins to view email recipients with their confirmed/unconfirmed status, add them to the Do Not Contact list, and delete them.