### PR TITLE
Make Plugin-loading Great Again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,16 @@
 # ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
 
 # Supporting methods for loading ShinyCMS plugin gems
-def plugin_names
-  return ENV[ 'SHINYCMS_PLUGINS' ].split( /[, ]+/ ) if ENV[ 'SHINYCMS_PLUGINS' ]
+def available_plugins
+  Dir[ 'plugins/*' ].sort.collect { |name| name.sub( 'plugins/', '' ) }
+end
 
-  Dir[ 'plugins/*' ].sort.collect { |plugin_name| plugin_name.sub( 'plugins/', '' ) }
+def plugin_names
+  requested = ENV[ 'SHINYCMS_PLUGINS' ]&.split( /[, ]+/ )
+
+  return requested.uniq.select { |name| available_plugins.include?( name ) } if requested
+
+  available_plugins
 end
 
 def underscore( camel_cased_word )

--- a/app/models/shiny_plugin.rb
+++ b/app/models/shiny_plugin.rb
@@ -114,7 +114,10 @@ class ShinyPlugin
   end
 
   def self.configured_names
-    ENV[ 'SHINYCMS_PLUGINS' ]&.split( /[, ]+/ )
+    requested = ENV[ 'SHINYCMS_PLUGINS' ]&.split( /[, ]+/ )
+    return if requested.blank?
+
+    requested.select { |name| all_names.include?( name ) }
   end
 
   def self.all_names

--- a/app/models/shiny_plugin.rb
+++ b/app/models/shiny_plugin.rb
@@ -117,7 +117,7 @@ class ShinyPlugin
     requested = ENV[ 'SHINYCMS_PLUGINS' ]&.split( /[, ]+/ )
     return if requested.blank?
 
-    requested.select { |name| all_names.include?( name ) }
+    requested.uniq.select { |name| all_names.include?( name ) }
   end
 
   def self.all_names

--- a/app/models/shiny_plugin.rb
+++ b/app/models/shiny_plugin.rb
@@ -115,9 +115,8 @@ class ShinyPlugin
 
   def self.configured_names
     requested = ENV[ 'SHINYCMS_PLUGINS' ]&.split( /[, ]+/ )
-    return if requested.blank?
 
-    requested.uniq.select { |name| all_names.include?( name ) }
+    return requested.uniq.select { |name| all_names.include?( name ) } if requested.present?
   end
 
   def self.all_names

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -6,8 +6,6 @@
 
 * .strip incoming email addresses
 
-* Don't try to load non-existent plugins from SHINYCMS_PLUGINS - check for existence in configured_names?
-
 * Get rid of 'precision: 6' on all timestamps? Seems excessive...
 
 

--- a/tools/heroku-release
+++ b/tools/heroku-release
@@ -1,3 +1,13 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Utility script to be run during each release/deploy on Heroku
+
 gem uninstall bundler --version 1.17.2
 bundle exec rails db:migrate
 bundle exec rails assets:precompile

--- a/tools/shiny-bundle-install
+++ b/tools/shiny-bundle-install
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Run `bundle install`, picking up any relevant ENV vars first (in particular, SHINYCMS_PLUGINS)
+
+dotenv -f .env.development.local bundle install

--- a/tools/shiny-sidekiq-dev
+++ b/tools/shiny-sidekiq-dev
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Run Sidekiq in dev, picking up any relevant ENV vars (SIDEKIQ_CONCURRENCY, SIDEKIQ_PREFIX, etc)
+
+dotenv -f .env.development.local sidekiq


### PR DESCRIPTION
* Handle wonky requested plugin lists more gracefully (ignore ones we don't have, ignore duplicates)

* Add wrapper script for running `bundle install` with ENV loaded - so we can look at SHINYCMS_PLUGINS and only install what was asked for)

* Add wrapper script for running sidekiq in dev with ENV loaded too, to pick up possible config from there