### PR TITLE
Strip emails

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Model for tracking website events using ahoy
 class Ahoy::Event < ApplicationRecord
   include Ahoy::QueryMethods

--- a/app/models/ahoy/message.rb
+++ b/app/models/ahoy/message.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Model for tracking emails using ahoy
 class Ahoy::Message < ApplicationRecord
   include ShinyPaging

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # Model for tracking website visits using ahoy
 class Ahoy::Visit < ApplicationRecord
   include ShinyPaging

--- a/app/models/do_not_contact.rb
+++ b/app/models/do_not_contact.rb
@@ -17,6 +17,7 @@ class DoNotContact < ApplicationRecord
 
   # Before/after actions
 
+  before_validation :strip_email, if: -> { email_changed? }
   before_save :redact_email
 
   # Class methods
@@ -44,6 +45,10 @@ class DoNotContact < ApplicationRecord
   end
 
   private
+
+  def strip_email
+    self.email = email.strip
+  end
 
   def redact_email
     self.email = DoNotContact.canonicalise_and_redact( email )

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -2,13 +2,6 @@
 
 ## TODO
 
-## Next / Soon
-
-* .strip incoming email addresses
-
-* Get rid of 'precision: 6' on all timestamps? Seems excessive...
-
-
 ## Features the Perl version has, which the Ruby version doesn't. Yet. :)
 
 ### Small-ish
@@ -31,7 +24,8 @@
 ### Large-ish
 
 * Access-controlled file downloads
-    * Can this be done with tokenised AWS links? And if yes, do I want that vendor lock-in? (Probably not?)
+    * Can this be done with tokenised AWS links? (Probably)
+    * If so, do I want that vendor lock-in? (Probably not)
 
 * Online shop
 


### PR DESCRIPTION
Strip whitespace from emails before we save them, in case of bad input data (seen in the wild from bots, meh).