### PR TITLE
Default blazer dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,8 @@ source 'https://rubygems.org' do
   gem 'ahoy_email'
   # Web stats
   gem 'ahoy_matey'
+  # Stats aggregation (save space by only keeping a summary of older data)
+  gem 'rollups'
   # Charts and dashboards
   gem 'blazer'
   # Charts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,6 +428,9 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
+    rollups (0.1.1)
+      activesupport (>= 5.1)
+      groupdate (>= 5.2)
     rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -591,6 +594,7 @@ DEPENDENCIES
   rails-pg-extras!
   rails_email_preview!
   recaptcha!
+  rollups!
   rspec-rails!
   rspec_junit_formatter!
   rubocop!

--- a/README.md
+++ b/README.md
@@ -32,25 +32,30 @@ To build a basic site on top of ShinyCMS, you just need to know HTML and ERB wel
 * [Mailing lists](docs/Features/Plugins/ShinyLists.md) ±
   * Double opt-in, user subscription management, 'do not contact' feature
 * [Newsletters](docs/Features/Plugins/ShinyNewsletters.md) ±
-  * HTML mailshots, produced from MJML templates for cross-platform compatibility
+  * HTML mailshots, generated from MJML templates for cross-platform compatibility
 * [Basic form handlers](docs/Features/Plugins/ShinyForms.md) ±
-  * e.g. 'email form data to site owner' - useful for contact and enquiry forms]
+  * e.g. 'email form data to site owner' - useful for contact and enquiry forms
   * Protected by [reCAPTCHA](https://developers.google.com/recaptcha/) and [Akismet](https://akismet.com/)
 * [Access control](docs/Features/Plugins/ShinyAccess.md) ±
-  * Create access groups, add/remove members, use helpers to show or hide content for different groups
+  * Create access groups, and add/remove members from them,
+  * Use the `current_user_can_access?( :group_name )` helper to show/hide content
 * [Site search](docs/Features/Plugins/ShinySearch.md) ±
   * Ready to support multiple search backends (default is pg_search multisearch)
 * [Tags](docs/Features/MainApp/Tags.md)
 * [Upvotes](docs/Features/MainApp/Upvotes.md) (AKA 'likes') on posts and comments
+  * Supports downvotes too, if you want a full rating/ranking system
 * [User profile pages](docs/Features/Plugins/ShinyProfiles.md) ±
-  * Links to user-provided content such as recent comments, recent blog posts, etc
+  * With links to user-generated content such as recent comments, recent blog posts, etc
 * [User accounts](docs/Features/MainApp/UserAccounts.md) and administration
   * ACL-based authorisation system for admins (powered by [Pundit](https://github.com/varvet/pundit))
   * Uses [reCAPTCHA](https://developers.google.com/recaptcha/) to block registration by bots
 * Web interface for [site settings](docs/Features/MainApp/SiteSettings.md) and [feature flags](docs/Features/MainApp/FeatureFlags.md)
-* Built-in tracking of [web stats](docs/Features/MainApp/WebStats.md) and [email stats](docs/Features/MainApp/EmailStats.md) (powered by [Ahoy](https://github.com/ankane/ahoy) and [Ahoy::Email](https://github.com/ankane/ahoy_email))
-* Build your own [charts and dashboards](docs/Features/MainApp/Charts.md) for viewing and analyzing stats (powered by [Blazer](https://github.com/ankane/blazer))
-* All emails are generated from [MJML](docs/Features/mjml.md) templates, producing reliably cross-platform HTML emails
+* All emails are generated from [MJML](docs/Features/mjml.md) templates, producing more reliably cross-platform HTML emails
+* Built-in tracking of [web stats](docs/Features/MainApp/WebStats.md) and [email stats](docs/Features/MainApp/EmailStats.md)
+  * Powered by [Ahoy](https://github.com/ankane/ahoy) and [Ahoy::Email](https://github.com/ankane/ahoy_email)
+* Build your own [charts and dashboards](docs/Features/MainApp/Charts.md) for viewing and analyzing stats
+  * Powered by [Blazer](https://github.com/ankane/blazer))
+  * Default dashboard config included, with a dozen chart-generating queries for you to use or learn from
 
 ### Planned features
 
@@ -59,7 +64,6 @@ To build a basic site on top of ShinyCMS, you just need to know HTML and ERB wel
 * Online shop
 * Support for multiple blogs on a single site (in progress)
 * [Algolia](https://www.algolia.com/) support for search plugin (in progress)
-* Default dashboard and charts for Blazer
 * More themes!
 
 

--- a/app/assets/stylesheets/shinycms/admin_area.scss
+++ b/app/assets/stylesheets/shinycms/admin_area.scss
@@ -232,6 +232,10 @@ form .ui-sortable-handle {
   padding-left:     0.5em;
 }
 
+.table-striped .width5pc {
+  width:            5%;
+}
+
 .table-striped .width16pc {
   width:            16%;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
   def current_user_can_view_charts?
     return true if current_user&.can? :view_charts, :stats
 
-    redirect_to main_app.admin_path, notice: "t( 'admin.stats.blazer.auth_fail' )"
+    redirect_to main_app.admin_path, notice: t( 'admin.blazer.auth_fail' )
   end
 
   def recaptcha_v3_site_key

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
   def current_user_can_view_charts?
     return true if current_user&.can? :view_charts, :stats
 
-    redirect_to main_app.admin_path, notice: t( 'admin.blazer.auth_fail' )
+    redirect_to main_app.admin_path, alert: t( 'admin.blazer.auth_fail' )
   end
 
   def recaptcha_v3_site_key

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,12 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def current_user_can_view_charts?
+    return true if current_user&.can? :view_charts, :stats
+
+    redirect_to main_app.admin_path, notice: "t( 'admin.stats.blazer.auth_fail' )"
+  end
+
   def recaptcha_v3_site_key
     ENV[ 'RECAPTCHA_V3_SITE_KEY' ]
   end

--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -17,7 +17,7 @@ class MainController < ApplicationController
   before_action :set_view_paths
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  after_action  :track_ahoy_visit
+  after_action  :track_ahoy_event, if: :ahoy_web_tracking_enabled?
 
   # Strong params config for Devise
   # rubocop:disable Layout/MultilineArrayLineBreaks
@@ -104,9 +104,12 @@ class MainController < ApplicationController
     request.referer.present? && request.referer != new_user_session_url
   end
 
-  # Track all actions with Ahoy
-  def track_ahoy_visit
-    ahoy.track 'Ran action', request.path_parameters
+  def ahoy_web_tracking_enabled?
+    FeatureFlag.enabled? :ahoy_web_tracking
+  end
+
+  def track_ahoy_event
+    ahoy.track "#{controller_name}: #{action_name}", request.path_parameters
   end
 
   def feeds_base_url

--- a/app/helpers/shiny_feature_flag_helper.rb
+++ b/app/helpers/shiny_feature_flag_helper.rb
@@ -20,14 +20,8 @@ module ShinyFeatureFlagHelper
   end
 
   def feature_enabled?( feature_name )
-    feature = FeatureFlag.find_by( name: feature_name.to_s )
+    return FeatureFlag.enabled? feature_name unless defined? current_user
 
-    return false if feature.blank?
-    return true  if feature.enabled?
-
-    # return false unless current_user&.can? :view_admin_area
-    return false unless current_user&.admin?
-
-    feature.enabled_for_admins?
+    FeatureFlag.enabled? feature_name, current_user
   end
 end

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -11,6 +11,7 @@ class Ahoy::Event < ApplicationRecord
   include Ahoy::QueryMethods
 
   self.table_name = 'ahoy_events'
+  self.rollup_column = :time
 
   belongs_to :visit
   belongs_to :user, optional: true

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -11,6 +11,7 @@ class Ahoy::Visit < ApplicationRecord
   include ShinyPaging
 
   self.table_name = 'ahoy_visits'
+  self.rollup_column = :started_at
 
   has_many :events, dependent: :destroy, class_name: 'Ahoy::Event'
   belongs_to :user, optional: true

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -24,11 +24,29 @@ class FeatureFlag < ApplicationRecord
     update! enabled: true, enabled_for_logged_in: true, enabled_for_admins: true
   end
 
+  alias on enable
+
   def disable
     update! enabled: false, enabled_for_logged_in: false, enabled_for_admins: false
   end
 
+  alias off disable
+
   # Class methods
+
+  def self.enabled?( name, user = nil )
+    feature = find_by( name: name.to_s )
+
+    return false if feature.blank?
+    return true  if feature.enabled?
+
+    return false if user.blank?
+    return true  if feature.enabled_for_logged_in?
+
+    return false unless user.admin?
+
+    feature.enabled_for_admins?
+  end
 
   def self.enable( name )
     flag = find_by!( name: name.to_s )

--- a/app/views/admin/email_stats/index.html.erb
+++ b/app/views/admin/email_stats/index.html.erb
@@ -25,7 +25,7 @@
     <% @messages.each do |message| %>
     <tr>
       <td>
-        <%= message.sent_at %>
+        <%= display_time_on_date( message.sent_at ) %>
       </td>
       <td>
         <% if message.user %><%= link_to message.user.email, user_email_stats_path( message.user ) %><% end %>

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -16,7 +16,7 @@
 
       <%# Other engines %>
       <% elsif plugin_name == 'Blazer' %>
-        <% @page_title = t( "admin.blazer.#{controller_name}.title" ) %> <%# TODO: i18n %>
+        <% @page_title = t( "admin.blazer.#{controller_name}.title" ) %>
         <%= link_to t( 'admin.stats.breadcrumb' ), blazer.root_path %>
       <% elsif plugin_name == 'RailsEmailPreview' %>
         <%= link_to t( 'rails_email_preview.breadcrumb' ), rails_email_preview.rep_root_path %>

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -16,8 +16,7 @@
 
       <%# Other engines %>
       <% elsif plugin_name == 'Blazer' %>
-        <% @do_not_yield = true if current_user_can? :view_charts %> <%# TODO: FIXME: This is vile; wrap Blazer in ShinyStats ASAP %>
-        <% @page_title = controller_name.titlecase %> <%# TODO: i18n %>
+        <% @page_title = t( "admin.blazer.#{controller_name}.title" ) %> <%# TODO: i18n %>
         <%= link_to t( 'admin.stats.breadcrumb' ), blazer.root_path %>
       <% elsif plugin_name == 'RailsEmailPreview' %>
         <%= link_to t( 'rails_email_preview.breadcrumb' ), rails_email_preview.rep_root_path %>

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -16,6 +16,7 @@
 
       <%# Other engines %>
       <% elsif plugin_name == 'Blazer' %>
+        <% @do_not_yield = true if current_user_can? :view_charts %> <%# TODO: FIXME: This is vile; wrap Blazer in ShinyStats ASAP %>
         <% @page_title = controller_name.titlecase %> <%# TODO: i18n %>
         <%= link_to t( 'admin.stats.breadcrumb' ), blazer.root_path %>
       <% elsif plugin_name == 'RailsEmailPreview' %>

--- a/app/views/admin/layouts/admin_area.html.erb
+++ b/app/views/admin/layouts/admin_area.html.erb
@@ -25,7 +25,7 @@
       <div class="c-body">
         <main>
           <%= render partial: 'admin/includes/messages' %>
-          <%= yield unless @do_not_yield %> <%# TODO: FIXME: This is vile; wrap Blazer in ShinyStats ASAP %>
+          <%= yield %>
         </main>
       </div>
 

--- a/app/views/admin/layouts/admin_area.html.erb
+++ b/app/views/admin/layouts/admin_area.html.erb
@@ -25,7 +25,7 @@
       <div class="c-body">
         <main>
           <%= render partial: 'admin/includes/messages' %>
-          <%= yield %>
+          <%= yield unless @do_not_yield %> <%# TODO: FIXME: This is vile; wrap Blazer in ShinyStats ASAP %>
         </main>
       </div>
 

--- a/app/views/admin/menu/_menu.html.erb
+++ b/app/views/admin/menu/_menu.html.erb
@@ -1,3 +1,5 @@
+<% return unless current_user_can? :view_admin_area %>
+
 <ul class="c-sidebar-nav">
   <% plugins_for_admin_menu.each do |plugin| %>
   <%= render partial: "#{plugin.name.underscore}/admin/menu/section" %>

--- a/app/views/admin/menu/_menu_item.html.erb
+++ b/app/views/admin/menu/_menu_item.html.erb
@@ -1,7 +1,13 @@
-<% item_id = text.parameterize %>
+<%
+  item_id = text.parameterize
+  active = ''
+  if request.path.starts_with? link
+    active = 'c-active'
+  end
+%>
 <a name="<%= item_id %>"></a>
 <li class="c-sidebar-nav-item">
-  <a class="c-sidebar-nav-link" href="<%= link %>">
+  <a class="c-sidebar-nav-link <%= active %>" href="<%= link %>">
     <i class="cil-<%= icon %>"></i> <%= text %>
     <% badge ||= false %>
     <% if badge %>

--- a/app/views/admin/menu/_menu_section_start.html.erb
+++ b/app/views/admin/menu/_menu_section_start.html.erb
@@ -1,7 +1,7 @@
 <% section_id = text.parameterize %>
-<% expand ||= false; show = expand ? ' c-show' : '' %>
 <a name="<%= section_id %>"></a>
-<li class="c-sidebar-nav-item c-sidebar-nav-dropdown<%= show %>" id="<%= section_id %>">
+<% expand ||= false %>
+<li class="c-sidebar-nav-item c-sidebar-nav-dropdown <%= 'c-show' if expand %>" id="<%= section_id %>">
   <a class="c-sidebar-nav-link c-sidebar-nav-dropdown-toggle" href="#<%= section_id %>">
     <% icon ||= false %>
     <% if icon %><i class="cil-<%= icon %>"></i><% end %> <b><%= text %></b>

--- a/app/views/admin/menu/_menu_section_start.html.erb
+++ b/app/views/admin/menu/_menu_section_start.html.erb
@@ -1,7 +1,7 @@
 <% section_id = text.parameterize %>
-<% expand = ' c-show' %>
+<% expand ||= false; show = expand ? ' c-show' : '' %>
 <a name="<%= section_id %>"></a>
-<li class="c-sidebar-nav-item c-sidebar-nav-dropdown<%= expand %>" id="<%= section_id %>">
+<li class="c-sidebar-nav-item c-sidebar-nav-dropdown<%= show %>" id="<%= section_id %>">
   <a class="c-sidebar-nav-link c-sidebar-nav-dropdown-toggle" href="#<%= section_id %>">
     <% icon ||= false %>
     <% if icon %><i class="cil-<%= icon %>"></i><% end %> <b><%= text %></b>

--- a/app/views/admin/menu/_stats.html.erb
+++ b/app/views/admin/menu/_stats.html.erb
@@ -12,6 +12,6 @@
         t( 'admin.email_stats.menu' ), email_stats_path, 'chart-pie' ) %>
 
     <%= render_admin_menu_item_if( current_user.can?( :make_charts, :stats ),
-        t( 'admin.charts.menu' ), blazer_path, 'chart-line' ) %>
+        t( 'admin.blazer.menu' ), blazer_path, 'chart-line' ) %>
 
   <% end %>

--- a/app/views/admin/web_stats/index.html.erb
+++ b/app/views/admin/web_stats/index.html.erb
@@ -6,7 +6,7 @@
 <table class="table table-responsive-sm table-striped">
   <thead>
     <tr>
-      <th>
+      <th colspan="2">
         Visit started
       </th>
       <th>
@@ -24,8 +24,11 @@
   <tbody>
     <% @visits.each do |visit| %>
     <tr>
+    <td class="width5pc">
+        <%= display_time( visit.started_at ) %>
+      </td>
       <td>
-        <%= visit.started_at %>
+        <%= display_date( visit.started_at ) %>
       </td>
       <td>
         <%= visit.ip %>

--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -14,7 +14,8 @@ check_schedules:
   - "5 minutes"
 
 # Create audits
-audit: <%= Setting.true? :blazer_log_queries %>
+# FIXME: using the application models during initialisation upsets newer Rails versions
+audit: true # <%#= Setting.true? :blazer_log_queries %>
 
 # Enable anomaly detection; note: with trend, time series are sent to https://trendapi.org
 # anomaly_checks: trend / r
@@ -27,8 +28,9 @@ audit: <%= Setting.true? :blazer_log_queries %>
 mapbox_access_token: <%= ENV[ 'MAPBOX_ACCESS_TOKEN' ] %>
 <% end %>
 
-# If we're in dev environment, allow fallback to main database details
+# Database credentials; generally this should be a separate, read-only user
 <% database_url = ENV[ 'BLAZER_DATABASE_URL' ].presence %>
+# If we're in dev environment, allow fallback to main database credentials
 <% database_url ||= ENV[ 'DATABASE_URL' ] if Rails.env.development? %>
 
 data_sources:
@@ -62,7 +64,8 @@ data_sources:
 time_zone: <%= Rails.application.config.time_zone %>
 
 # Email to send checks from
-from_email: <%= Setting.get :site_email %>
+# FIXME: using the application models during initialisation upsets newer Rails versions
+# from_email: <%#= Setting.get :site_email %>
 
 # Display-name method
 user_name: username

--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -8,14 +8,18 @@
 
 # See https://github.com/ankane/blazer#readme for more info about this config file
 
+# Email to send checks from
+<% if ENV[ 'SHINYCMS_SITE_EMAIL' ].present? %>
+from_email: <%= ENV[ 'SHINYCMS_SITE_EMAIL' ] %>
+
 check_schedules:
   - "1 day"
   - "1 hour"
   - "5 minutes"
+<% end %>
 
-# Create audits
-# FIXME: using the application models during initialisation upsets newer Rails versions
-audit: true # <%#= Setting.true? :blazer_log_queries %>
+# Audit logs
+audit: <%= ENV.fetch( 'BLAZER_AUDIT_LOG', 'true' ) %>
 
 # Enable anomaly detection; note: with trend, time series are sent to https://trendapi.org
 # anomaly_checks: trend / r
@@ -62,10 +66,6 @@ data_sources:
     # use_transaction: false
 
 time_zone: <%= Rails.application.config.time_zone %>
-
-# Email to send checks from
-# FIXME: using the application models during initialisation upsets newer Rails versions
-# from_email: <%#= Setting.get :site_email %>
 
 # Display-name method
 user_name: username

--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -6,76 +6,66 @@
 #
 # ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
 
-# See https://github.com/ankane/blazer for more info about this config file
-
-data_sources:
-  main:
-    url: <%= ENV["BLAZER_DATABASE_URL"] %>
-
-    # statement timeout, in seconds
-    # none by default
-    # timeout: 15
-
-    # caching settings
-    # can greatly improve speed
-    # off by default
-    # cache:
-    #   mode: slow # or all
-    #   expires_in: 60 # min
-    #   slow_threshold: 15 # sec, only used in slow mode
-
-    # wrap queries in a transaction for safety
-    # not necessary if you use a read-only user
-    # true by default
-    # use_transaction: false
-
-    smart_variables:
-      # zone_id: "SELECT id, name FROM zones ORDER BY name ASC"
-      # period: ["day", "week", "month"]
-      # status: {0: "Active", 1: "Archived"}
-
-    linked_columns:
-      # user_id: "/admin/users/{value}"
-
-    smart_columns:
-      # user_id: "SELECT id, name FROM users WHERE id IN {value}"
-
-# create audits
-audit: true
-
-# change the time zone
-# time_zone: "Pacific Time (US & Canada)"
-
-# class name of the user model
-# user_class: User
-
-# method name for the current user
-# user_method: current_user
-
-# method name for the display name
-# user_name: name
-
-# custom before_action to use for auth
-# before_action_method: require_admin
-
-# email to send checks from
-# from_email: blazer@example.org
-
-# webhook for Slack
-# slack_webhook_url: <%= ENV["BLAZER_SLACK_WEBHOOK_URL"] %>
+# See https://github.com/ankane/blazer#readme for more info about this config file
 
 check_schedules:
   - "1 day"
   - "1 hour"
   - "5 minutes"
 
-# enable anomaly detection
-# note: with trend, time series are sent to https://trendapi.org
+# Create audits
+audit: <%= Setting.true? :blazer_log_queries %>
+
+# Enable anomaly detection; note: with trend, time series are sent to https://trendapi.org
 # anomaly_checks: trend / r
 
-# enable forecasting
-# note: with trend, time series are sent to https://trendapi.org
+# Enable forecasting; note: with trend, time series are sent to https://trendapi.org
 # forecasting: trend
 
-# enable map
-# mapbox_access_token: <%= ENV["MAPBOX_ACCESS_TOKEN"] %>
+# Enable map
+<% if ENV[ 'MAPBOX_ACCESS_TOKEN' ].present? %>
+mapbox_access_token: <%= ENV[ 'MAPBOX_ACCESS_TOKEN' ] %>
+<% end %>
+
+# If we're in dev environment, allow fallback to main database details
+<% database_url = ENV[ 'BLAZER_DATABASE_URL' ].presence %>
+<% database_url ||= ENV[ 'DATABASE_URL' ] if Rails.env.development? %>
+
+data_sources:
+  shinycms:
+    url: <%= database_url %>
+
+    smart_variables:
+      device_type: "select '%' as id, 'all' as label union select distinct device_type as id, device_type as label from ahoy_visits order by label"
+      # zone_id: "SELECT id, name FROM zones ORDER BY name ASC"
+      # period: ["day", "week", "month"]
+      # status: {0: "Active", 1: "Archived"}
+
+    linked_columns:
+      user_id: "/admin/users/{value}"
+
+    smart_columns:
+      user_id: "SELECT id, name FROM users WHERE id IN {value}"
+
+    # statement timeout, in seconds - none by default
+    # timeout: 15
+
+    # caching settings, can greatly improve speed - off by default
+    # cache:
+    #   mode: slow # or all
+    #   expires_in: 60 # min
+    #   slow_threshold: 15 # sec, only used in slow mode
+
+    # wrap queries in a transaction for safety - not necessary if you use a read-only user - true by default
+    # use_transaction: false
+
+time_zone: <%= Rails.application.config.time_zone %>
+
+# Email to send checks from
+from_email: <%= Setting.get :site_email %>
+
+# Display-name method
+user_name: username
+
+# Custom before_action to use for auth (defined in ApplicationController)
+before_action_method: current_user_can_view_charts?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,6 +476,7 @@ en:
 
     blazer:
       menu: Charts
+      auth_fail: You do not have permission to view charts
       dashboards:
         title: Dashboards
       queries:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,8 @@ en:
   feature_flags:
     off_alert: Sorry, the '%{feature_name}' feature of this site is not available.
 
+    ahoy_email_tracking: Track email opens/clicks
+    ahoy_web_tracking: Track web visitor stats
     akismet_for_comments: Detect spam comments with Akismet
     comments: Comments
     comment_notifications: Comment notifications

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -474,16 +474,14 @@ en:
       menu: Stats
       breadcrumb: Stats
 
-    # Blazer
-    charts:
+    blazer:
       menu: Charts
-      # title: Charts
-    # checks:
-      # title: Checks
-    # dashboards:
-      # title: Dashboards
-    # queries:
-      # title: Queries
+      dashboards:
+        title: Dashboards
+      queries:
+        title: Queries
+      checks:
+        title: Checks
 
     web_stats:
       breadcrumb: Stats

--- a/db/migrate/20201121073328_create_rollups.rb
+++ b/db/migrate/20201121073328_create_rollups.rb
@@ -1,0 +1,12 @@
+class CreateRollups < ActiveRecord::Migration[6.0]
+  def change
+    create_table :rollups do |t|
+      t.string :name, null: false
+      t.string :interval, null: false
+      t.datetime :time, null: false
+      t.jsonb :dimensions, null: false, default: {}
+      t.float :value
+    end
+    add_index :rollups, [:name, :interval, :time, :dimensions], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,18 +1,16 @@
-# frozen_string_literal: true
-
-# ShinyCMS ~ https://shinycms.org
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
 #
-# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
-#
-# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
-
 # This file is the source Rails uses to define your schema when running `rails
 # db:schema:load`. When creating a new database, `rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_11_195416) do
+ActiveRecord::Schema.define(version: 2020_11_21_073328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -271,6 +269,15 @@ ActiveRecord::Schema.define(version: 2020_11_11_195416) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
+  end
+
+  create_table "rollups", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "interval", null: false
+    t.datetime "time", null: false
+    t.jsonb "dimensions", default: {}, null: false
+    t.float "value"
+    t.index ["name", "interval", "time", "dimensions"], name: "index_rollups_on_name_and_interval_and_time_and_dimensions", unique: true
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 2020_11_21_073328) do
   end
 
   create_table "comment_authors", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.string "website"
     t.inet "ip_address", null: false
     t.uuid "token", null: false
@@ -186,19 +186,19 @@ ActiveRecord::Schema.define(version: 2020_11_21_073328) do
     t.integer "discussion_id", null: false
     t.integer "number", null: false
     t.bigint "parent_id"
+    t.string "author_type"
+    t.bigint "author_id"
     t.string "title"
     t.text "body"
     t.string "ip_address"
     t.boolean "locked", default: false, null: false
     t.boolean "show_on_site", default: true, null: false
     t.boolean "spam", default: false, null: false
-    t.string "author_type"
-    t.bigint "author_id"
     t.datetime "posted_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deleted_at", precision: 6
-    t.index ["author_type", "author_id"], name: "index_comments_on_author_type_and_author_id"
+    t.index ["author_id", "author_type"], name: "index_comments_on_author_id_and_author_type"
     t.index ["deleted_at"], name: "index_comments_on_deleted_at"
     t.index ["number", "discussion_id"], name: "index_comments_on_number_and_discussion_id", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,14 +1,16 @@
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
 #
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 # This file is the source Rails uses to define your schema when running `rails
 # db:schema:load`. When creating a new database, `rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
-#
-# It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_11_21_073328) do
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,6 +25,9 @@ ShinyPlugin.loaded.each do |plugin|
   Rake::Task[ "#{plugin.name.underscore}:db:seed" ].invoke
 end
 
+# Load default dashboard data for Blazer
+require_relative 'seeds/blazer' unless ENV['DISABLE_BLAZER'].presence == 'true'
+
 # If there are currently no super-admin users, show the command to create one
 demo = ( Rake.application.top_level_tasks.first == 'shiny:demo:load' )
 skip = User.super_admins_exist? || demo || Rails.env.test?

--- a/db/seeds/blazer.rb
+++ b/db/seeds/blazer.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# This file sets up the default dashboard and queries for Blazer
+
+# Adapted from https://github.com/resool/blazer-demo
+
+# Dashboard
+dashboard = Blazer::Dashboard.where( name: 'Default' ).first_or_create!
+
+# Users
+sql = <<~SQL.squish
+  SELECT username, email,
+         CASE confirmed_at WHEN NULL THEN 'Not Confirmed' ELSE 'Confirmed' END as status,
+         DATE(created_at) AS created_on,
+         DATE(confirmed_at) AS confirmed_on
+    FROM users
+   WHERE created_at >= {start_time}
+     AND created_at <= {end_time}
+SQL
+
+query = Blazer::Query.where( name: 'User accounts' ).first_or_create!(
+  description: 'User accounts, with confirmed/unconfirmed status',
+  data_source: 'shinycms',
+  statement: sql
+)
+dashboard.queries << query unless dashboard.queries.exists? query.id
+
+# Most popular browsers
+sql = <<~SQL.squish
+  WITH browsers AS (
+    SELECT browser, count(*)
+      FROM ahoy_visits
+     WHERE started_at > {start_time}
+       AND started_at < {end_time}
+     GROUP BY browser
+     ORDER BY count desc
+  ),
+  tops AS (
+    SELECT *
+      FROM browsers
+     LIMIT 4
+  ),
+  others AS (
+    SELECT *
+      FROM browsers
+    OFFSET 4
+  )
+  SELECT *
+    FROM tops
+   UNION
+  SELECT 'Other', SUM(count)
+    FROM others
+SQL
+
+query = Blazer::Query.where( name: 'Browsers' ).first_or_create!(
+  description: 'Most popular browsers',
+  data_source: 'shinycms',
+  statement: sql
+)
+dashboard.queries << query unless dashboard.queries.exists? query.id

--- a/db/seeds/blazer.rb
+++ b/db/seeds/blazer.rb
@@ -8,24 +8,41 @@
 
 # This file sets up the default dashboard and queries for Blazer
 
-# Adapted from https://github.com/resool/blazer-demo
+# Several of these were copied or adapted from https://github.com/resool/blazer-demo
 
 # Dashboard
-dashboard = Blazer::Dashboard.where( name: 'Default' ).first_or_create!
+dashboard = Blazer::Dashboard.where( name: 'Default Dashboard' ).first_or_create!
 
 # Users
 sql = <<~SQL.squish
-  SELECT username, email,
-         CASE confirmed_at WHEN NULL THEN 'Not Confirmed' ELSE 'Confirmed' END as status,
-         DATE(created_at) AS created_on,
-         DATE(confirmed_at) AS confirmed_on
-    FROM users
-   WHERE created_at >= {start_time}
-     AND created_at <= {end_time}
+  select date( created_at ) as accounts_created_on,
+         case ( confirmed_at is not null ) when true then 'Confirmed' else 'Not confirmed' end as confirmation_status,
+         count(*) as user_count
+    from users
+   where created_at between {start_time} and {end_time}
+   group by 1, 2
+   order by 1, 2
 SQL
 
 query = Blazer::Query.where( name: 'New user accounts' ).first_or_create!(
-  description: 'New user accounts, with confirmed/unconfirmed status',
+  description: 'Number of new user accounts created on each day in this range, split by confirmation status',
+  data_source: 'shinycms',
+  statement: sql
+)
+dashboard.queries << query unless dashboard.queries.exists? query.id
+
+# Comment authors
+sql = <<~SQL.squish
+  select date( created_at ) as first_posted_on,
+         count(*) as author_count
+    from comment_authors
+   where created_at between {start_time} and {end_time}
+   group by 1
+   order by 1
+SQL
+
+query = Blazer::Query.where( name: 'New comment authors' ).first_or_create!(
+  description: 'Number of first-time pseudonymous commenters for each day in this range',
   data_source: 'shinycms',
   statement: sql
 )
@@ -33,38 +50,92 @@ dashboard.queries << query unless dashboard.queries.exists? query.id
 
 # Email recipients
 sql = <<~SQL.squish
-  SELECT name, email,
-         CASE confirmed_at WHEN NULL THEN 'Not Confirmed' ELSE 'Confirmed' END as status,
-         DATE(created_at) AS created_on,
-         DATE(confirmed_at) AS confirmed_on
-    FROM email_recipients
-   WHERE created_at >= {start_time}
-     AND created_at <= {end_time}
+  select date( created_at ) as created_on,
+         case ( confirmed_at is not null ) when true then 'Confirmed' else 'Not confirmed' end as confirmation_status,
+         count(*) as recipient_count
+    from email_recipients
+   where created_at between {start_time} and {end_time}
+   group by 1, 2
+   order by 1, 2
 SQL
 
 query = Blazer::Query.where( name: 'New email recipients' ).first_or_create!(
-  description: 'New email recipients (no user account), with confirmed/unconfirmed status',
+  description: 'Number of new email recipients (subscribers who are not users) created on each day in this range',
   data_source: 'shinycms',
   statement: sql
 )
 dashboard.queries << query unless dashboard.queries.exists? query.id
 
-# Countries
+# Comments
 sql = <<~SQL.squish
-  WITH countries AS (
-    SELECT country, count(*)
-      FROM ahoy_visits
-     WHERE started_at > {start_time}
-       AND started_at < {end_time}
-     GROUP BY country
-     ORDER BY count
-  )
-  SELECT country, count::text as count
-    FROM countries
+  select date(c.posted_at) as date_posted,
+         d.resource_type as type_of_content,
+         count(*) as comment_count
+    from comments c, discussions d
+   where c.discussion_id = d.id
+     and c.posted_at between {start_time} and {end_time}
+   group by 1, 2
+   order by 1, 2
 SQL
 
-query = Blazer::Query.where( name: 'Countries' ).first_or_create!(
-  description: 'Countries that visits are from',
+query = Blazer::Query.where( name: 'New comments' ).first_or_create!(
+  description: 'Number of comments posted on each day in this range, for each type of content with comments',
+  data_source: 'shinycms',
+  statement: sql
+)
+dashboard.queries << query unless dashboard.queries.exists? query.id
+
+# Visits
+sql = <<~SQL.squish
+  select date( started_at ) as visit_started_on,
+         case ( user_id is not null ) when true then 'Logged-in user' else 'Not logged-in' end as login_status,
+         count(*) AS visits
+    from ahoy_visits
+   where started_at between {start_time} and {end_time}
+   group by 1, 2
+   union all
+  select date( started_at ) as visit_started_on, 'All' as login_status, count(*) AS visits
+    from ahoy_visits
+   where started_at between {start_time} and {end_time}
+   group by 1, 2
+   order by 1 asc, 2 desc
+SQL
+
+query = Blazer::Query.where( name: 'All visits' ).first_or_create!(
+  description: 'Total number of visits on each day in this range, and split by login status',
+  data_source: 'shinycms',
+  statement: sql
+)
+dashboard.queries << query unless dashboard.queries.exists? query.id
+
+# Most popular browsers
+sql = <<~SQL.squish
+  WITH browsers AS (
+    select browser, count(*)
+      from ahoy_visits
+     where started_at between {start_time} and {end_time}
+     group by 1
+     order by 2 desc
+  ),
+  tops AS (
+    SELECT *
+      FROM browsers
+     LIMIT 4
+  ),
+  others AS (
+    SELECT *
+      FROM browsers
+    OFFSET 4
+  )
+  SELECT *
+    FROM tops
+   UNION
+  SELECT 'Other', SUM(count)
+    FROM others
+SQL
+
+query = Blazer::Query.where( name: 'Popular web browsers' ).first_or_create!(
+  description: "Total number of visits between these dates, split by web browser used (shows top 4 and 'other')",
   data_source: 'shinycms',
   statement: sql
 )
@@ -72,32 +143,111 @@ dashboard.queries << query unless dashboard.queries.exists? query.id
 
 # Devices
 sql = <<~SQL.squish
-  SELECT device_type, count(*)
-    FROM ahoy_visits
-   WHERE started_at >= {start_time}
-     AND started_at <= {end_time}
-   GROUP BY device_type
-   ORDER BY count DESC
+  select device_type, count(*) as visits_from_device_type
+    from ahoy_visits
+   where started_at between {start_time} and {end_time}
+   group by 1
+   order by 1 desc
 SQL
 
 query = Blazer::Query.where( name: 'Device types' ).first_or_create!(
-  description: 'Types of device',
+  description: 'Number of visits between these dates from each device type listed',
   data_source: 'shinycms',
   statement: sql
 )
 dashboard.queries << query unless dashboard.queries.exists? query.id
 
-# Visitor Map
-sql = <<~SQL.squish
-  SELECT lat, lng
-    FROM ahoy_visits
-  WHERE started_at >= {start_time}
-    AND started_at <= {end_time}
-SQL
+# TODO: FIXME: we're not recording country data currently, so this is not very useful.
+# Countries
+# sql = <<~SQL.squish
+#  select country, count(*) as visits_from_country
+#    from ahoy_visits
+#   where started_at between {start_time} and {end_time}
+#   group by 1
+#   order by 1 desc
+# SQL
+#
+# query = Blazer::Query.where( name: 'Countries' ).first_or_create!(
+#  description: 'Number of visits between these dates that came from each country listed',
+#  data_source: 'shinycms',
+#  statement: sql
+# )
+# dashboard.queries << query unless dashboard.queries.exists? query.id
 
-query = Blazer::Query.where( name: 'Visitor map' ).first_or_create!(
-  description: 'Map view of visitor locations',
-  data_source: 'shinycms',
-  statement: sql
-)
-dashboard.queries << query if ENV[ 'MAPBOX_ACCESS_TOKEN' ].present? && !dashboard.queries.exists?( query.id )
+# Access group memberships
+if ShinyPlugin.loaded? :ShinyAccess
+  sql = <<~SQL.squish
+    select date( began_at ) as began_on,
+           g.internal_name as group_name,
+           count(*) as memberships_begun
+      from shiny_access_memberships m, shiny_access_groups g
+     where m.group_id = g.id
+       and began_at between {start_time} and {end_time}
+     group by 1, 2
+     order by 1, 2
+  SQL
+
+  query = Blazer::Query.where( name: 'Memberships that began on these dates' ).first_or_create!(
+    description: 'Number of access control group memberships that began on each day in this range',
+    data_source: 'shinycms',
+    statement: sql
+  )
+  dashboard.queries << query unless dashboard.queries.exists? query.id
+
+  sql = <<~SQL.squish
+    select date( ended_at ) as ended_on,
+           g.internal_name as group_name,
+           count(*) as memberships_ended
+      from shiny_access_memberships m, shiny_access_groups g
+     where m.group_id = g.id
+       and ended_at between {start_time} and {end_time}
+     group by 1, 2
+     order by 1, 2
+  SQL
+
+  query = Blazer::Query.where( name: 'Memberships that ended on these dates' ).first_or_create!(
+    description: 'Number of access control group memberships that ended on each day in this range',
+    data_source: 'shinycms',
+    statement: sql
+  )
+  dashboard.queries << query unless dashboard.queries.exists? query.id
+end
+
+# Mailing list subscriptions
+if ShinyPlugin.loaded? :ShinyLists
+  sql = <<~SQL.squish
+    select date( subscribed_at ) as subscribed_on,
+           l.internal_name as list_name,
+           count(*) as subscription_count
+      from shiny_lists_subscriptions s, shiny_lists_lists l
+     where s.list_id = l.id
+       and subscribed_at between {start_time} and {end_time}
+     group by 1, 2
+     order by 1, 2
+  SQL
+
+  query = Blazer::Query.where( name: 'Mailing list subscriptions' ).first_or_create!(
+    description: 'Number of mailing list subscriptions on each day in this range',
+    data_source: 'shinycms',
+    statement: sql
+  )
+  dashboard.queries << query unless dashboard.queries.exists? query.id
+
+  sql = <<~SQL.squish
+    select date( unsubscribed_at ) as unsubscribed_on,
+           l.internal_name as list_name,
+           count(*) as unsubscribe_count
+      from shiny_lists_subscriptions s, shiny_lists_lists l
+     where s.list_id = l.id
+       and unsubscribed_at between {start_time} and {end_time}
+     group by 1, 2
+     order by 1, 2
+  SQL
+
+  query = Blazer::Query.where( name: 'Mailing list unsubscribes' ).first_or_create!(
+    description: 'Number of mailing list unsubscribes on each day in this range',
+    data_source: 'shinycms',
+    statement: sql
+  )
+  dashboard.queries << query unless dashboard.queries.exists? query.id
+end

--- a/db/seeds/blazer.rb
+++ b/db/seeds/blazer.rb
@@ -24,43 +24,80 @@ sql = <<~SQL.squish
      AND created_at <= {end_time}
 SQL
 
-query = Blazer::Query.where( name: 'User accounts' ).first_or_create!(
-  description: 'User accounts, with confirmed/unconfirmed status',
+query = Blazer::Query.where( name: 'New user accounts' ).first_or_create!(
+  description: 'New user accounts, with confirmed/unconfirmed status',
   data_source: 'shinycms',
   statement: sql
 )
 dashboard.queries << query unless dashboard.queries.exists? query.id
 
-# Most popular browsers
+# Email recipients
 sql = <<~SQL.squish
-  WITH browsers AS (
-    SELECT browser, count(*)
+  SELECT name, email,
+         CASE confirmed_at WHEN NULL THEN 'Not Confirmed' ELSE 'Confirmed' END as status,
+         DATE(created_at) AS created_on,
+         DATE(confirmed_at) AS confirmed_on
+    FROM email_recipients
+   WHERE created_at >= {start_time}
+     AND created_at <= {end_time}
+SQL
+
+query = Blazer::Query.where( name: 'New email recipients' ).first_or_create!(
+  description: 'New email recipients (no user account), with confirmed/unconfirmed status',
+  data_source: 'shinycms',
+  statement: sql
+)
+dashboard.queries << query unless dashboard.queries.exists? query.id
+
+# Countries
+sql = <<~SQL.squish
+  WITH countries AS (
+    SELECT country, count(*)
       FROM ahoy_visits
      WHERE started_at > {start_time}
        AND started_at < {end_time}
-     GROUP BY browser
-     ORDER BY count desc
-  ),
-  tops AS (
-    SELECT *
-      FROM browsers
-     LIMIT 4
-  ),
-  others AS (
-    SELECT *
-      FROM browsers
-    OFFSET 4
+     GROUP BY country
+     ORDER BY count
   )
-  SELECT *
-    FROM tops
-   UNION
-  SELECT 'Other', SUM(count)
-    FROM others
+  SELECT country, count::text as count
+    FROM countries
 SQL
 
-query = Blazer::Query.where( name: 'Browsers' ).first_or_create!(
-  description: 'Most popular browsers',
+query = Blazer::Query.where( name: 'Countries' ).first_or_create!(
+  description: 'Countries that visits are from',
   data_source: 'shinycms',
   statement: sql
 )
 dashboard.queries << query unless dashboard.queries.exists? query.id
+
+# Devices
+sql = <<~SQL.squish
+  SELECT device_type, count(*)
+    FROM ahoy_visits
+   WHERE started_at >= {start_time}
+     AND started_at <= {end_time}
+   GROUP BY device_type
+   ORDER BY count DESC
+SQL
+
+query = Blazer::Query.where( name: 'Device types' ).first_or_create!(
+  description: 'Types of device',
+  data_source: 'shinycms',
+  statement: sql
+)
+dashboard.queries << query unless dashboard.queries.exists? query.id
+
+# Visitor Map
+sql = <<~SQL.squish
+  SELECT lat, lng
+    FROM ahoy_visits
+  WHERE started_at >= {start_time}
+    AND started_at <= {end_time}
+SQL
+
+query = Blazer::Query.where( name: 'Visitor map' ).first_or_create!(
+  description: 'Map view of visitor locations',
+  data_source: 'shinycms',
+  statement: sql
+)
+dashboard.queries << query if ENV[ 'MAPBOX_ACCESS_TOKEN' ].present? && !dashboard.queries.exists?( query.id )

--- a/db/seeds/feature_flags.rb
+++ b/db/seeds/feature_flags.rb
@@ -30,3 +30,7 @@ add_feature_flag( name: 'downvotes',                   description: 'Enable down
 # These two are disabled by default, to reduce the risk of brute force attacks on new/dev/demo sites
 add_feature_flag( name: 'user_login',        description: 'Allow users to log in',                enabled: false )
 add_feature_flag( name: 'user_registration', description: 'Allow new users to create an account', enabled: false )
+
+# These two are disabled by default for privacy reasons
+add_feature_flag( name: 'ahoy_web_tracking',   description: 'Track data about website visitors', enabled: false )
+add_feature_flag( name: 'ahoy_email_tracking', description: 'Track email opens and clicks',      enabled: false )

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -2,6 +2,8 @@
 
 ## TODO
 
+* Tags don't honour show/hide status
+
 ## Features the Perl version has, which the Ruby version doesn't. Yet. :)
 
 ### Small-ish

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -110,9 +110,7 @@
     * Decide 'intelligently' whether to fold all/none/some
         * (e.g. if there are >20 pages in total, fold any section containing >10 pages; if there are >10 sections and >100 pages in total, fold all sections; etc)
 
-* Wrap Blazer in a thin ShinyStats plugin, to give it:
-    * Standard authorisation and authentication (currently implemented _in the admin views_, ewww)
-    * Standard feature flagging, so people can choose not to load it
+* Wrap Blazer in a thin ShinyStats plugin, to give it standard auth and feature flagging
 
 * ShowHide could be abstracted more AND be more useful, as a polymorphic acts_as_showable
   sort of thing - giving us show_on( :site ), show_in( :menus ), show_on( :sitemap ), etc

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -104,6 +104,10 @@
     * Decide 'intelligently' whether to fold all/none/some
         * (e.g. if there are >20 pages in total, fold any section containing >10 pages; if there are >10 sections and >100 pages in total, fold all sections; etc)
 
+* Wrap Blazer in a thin ShinyStats plugin, to give it:
+    * Standard authorisation and authentication (currently implemented _in the admin views_, ewww)
+    * Standard feature flagging, so people can choose not to load it
+
 * ShowHide could be abstracted more AND be more useful, as a polymorphic acts_as_showable
   sort of thing - giving us show_on( :site ), show_in( :menus ), show_on( :sitemap ), etc
 

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -2,7 +2,11 @@
 
 ## TODO
 
-* Tags don't honour show/hide status
+* Tag cloud/list don't honour show/hide status of content
+
+* On email recipients admin page, link to a summary of their comments and newsletter subscriptions (if any exist)
+
+* Delete ahoy and session data when Akismet reports blatant spam? (make configurable)
 
 ## Features the Perl version has, which the Ruby version doesn't. Yet. :)
 

--- a/docs/Developers/done.md
+++ b/docs/Developers/done.md
@@ -54,34 +54,30 @@
       * The Perl version has role-based authorisation. The Ruby version has
       more flexible ACL-based authorisation (powered by Pundit).
       * MJML templates for all user account emails (welcome, forgot password, etc)
-* reCAPTCHA bot protection for registration and comment forms
+* reCAPTCHA bot protection for registrations, comments, and forms
     * Improvements: supports reCAPTCHA v3 with scores. Tries an invisible
     CAPTCHA first, falling back to an interactive CAPTCHA if that fails.
-* Akismet support, to flag potential spam comments
-    * Moderation queue in admin area
+* Akismet support, to flag potential spam comments and form submissions
+    * Comment moderation queue in admin area
     * Confirming/removing flag sends ham/spam training data to Akismet
     * Improvements: the Perl version doesn't feed back to Akismet (yet)
 
 ### Features that the Perl version didn't have, but the Ruby version does
 
 * Support for themes
-    * Override the core templates on a per-file, as-needed basis
+    * Low-lift; override the core templates on a per-file, as-needed basis
     * Two themes included
 * ShinyConcerns
     * While re-implementing various features I've tried to pull useful common
       functionality out into concerns, that might be handy building blocks for
       anybody else who wants to write a ShinyCMS plugin
-* Built-in email stats
-    * Track opens and/or link-clicks
-    * Disabled in default settings (privacy, yay!)
-    * Powered by Ahoy::Email
-* Built-in web stats
-    * Track visits, visitors, page views, etc
-    * Support for GDPR-friendly stats (IP masking, etc)
-    * Disabled in default settings
-    * Powered by Ahoy
 * Recoverable soft delete on almost all models (powered by ActsAsParanoid)
 * Admin page for viewing/managing (non-user) email recipients
+* Email open and click tracking (powered by Ahoy::Email)
+    * Disabled by default (privacy, yay!)
+* Web tracking (powered by Ahoy) - track visits, visitors, page views, etc
+    * Disabled by default, and has support for GDPR-friendly stats (IP masking, etc)
+* Build your own charts and dashboards to dig into the data gathered by Ahoy (powered by Blazer)
 
 
 ## TODO / In Progress

--- a/docs/Developers/in-progress.md
+++ b/docs/Developers/in-progress.md
@@ -31,10 +31,6 @@ Features that I'm halfway through implementing (with notes on where I'm up to, w
             * Look at Combustion, for minimal test apps for gems: https://github.com/pat/combustion
             * List ShinyBlog on https://www.ruby-toolbox.com/categories/Blog_Engines
 
-* Blazer charts (etc); feature is merged, but needs a default dashboard and queries setting up:
-    * https://github.com/resool/blazer-demo/commit/bd24fbbbc0d8ba2de5b33cd3ec2c58713cffbc2b
-    * https://github.com/resool/blazer-demo/commit/9d8ba40a223df6da668ca2b1786fdfc0b2fe0e76
-
 * Algolia search backend: https://devcenter.heroku.com/articles/algoliasearch#using-with-rails
     * NB: Not free to non-commercial sites using the CMS :(
     * Breaking news from Bundler: A new major version is available for Algolia! Please now use the https://rubygems.org/gems/algolia gem to get the latest features.

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -50,7 +50,7 @@ namespace :shiny do
     end
 
     task confirm: %i[ environment dotenv ] do
-      msg = 'Loading the demo site data wipes the database. Are you sure? [y/N] '
+      msg = 'Loading the demo site data wipes the database. Are you sure? (y/N) '
       $stdout.print msg
       unless $stdin.gets.chomp.downcase.in? %w[ y yes ]
         puts 'Thank you. No action taken, database is unchanged.'

--- a/lib/tasks/rollups.rake
+++ b/lib/tasks/rollups.rake
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+require 'dotenv/tasks'
+
+# ShinyCMS tasks for generated aggregated stats, and deleting the full data (to save space)
+
+namespace :shiny do
+  namespace :db do
+    desc 'ShinyCMS: aggregate web traffic data'
+    # :nocov:
+    task rollup: %i[ environment dotenv ] do
+      rollup_ahoy
+    end
+    # :nocov:
+
+    desc 'ShinyCMS: aggregate web traffic data, and remove the full data'
+    # :nocov:
+    task rollup_and_remove: %i[ environment dotenv ] do
+      rollup_ahoy
+
+      Ahoy::Visit.where( 'started_at < ?', 7.days.ago ).delete_all
+    end
+
+    def rollup_ahoy
+      Rollup.week_start = :monday
+
+      Ahoy::Visit.rollup( 'Visits', interval: :hour )
+      Ahoy::Visit.where.not( user_id: nil ).rollup( 'Visits (logged-in users)', interval: :hour )
+
+      Ahoy::Event.where( name: 'Ran action' )
+                 .where_props( controller: 'shiny_blog/blog', action: 'show' )
+                 .group_prop( :year, :month, :title )
+                 .rollup( 'Blog post views' )
+    end
+    # :nocov:
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,11 +55,15 @@ end
 
 RSpec.configure do |config|
   config.before( :suite ) do
-    # Wipe the test database, then load the required seed data
-    # (feature flags, capabilities and their categories, etc)
     DatabaseCleaner.clean_with :truncation
+
+    # Load feature flags, capabilities, etc
     ShinyCMS::Application.load_tasks
     Rake::Task['db:seed'].invoke
+
+    # These default to off for privacy, but we want to test the integration
+    FeatureFlag.enable :ahoy_web_tracking
+    FeatureFlag.enable :ahoy_email_tracking
   end
 
   config.before :each do

--- a/spec/requests/admin/stats_spec.rb
+++ b/spec/requests/admin/stats_spec.rb
@@ -11,7 +11,7 @@ require 'rails_helper'
 # Tests for the Blazer integration
 RSpec.describe 'Blazer (charts and dashboards)', type: :request do
   before :each do
-    admin = create :admin_user
+    admin = create :stats_admin
     sign_in admin
   end
 
@@ -21,7 +21,8 @@ RSpec.describe 'Blazer (charts and dashboards)', type: :request do
 
       expect( response      ).to have_http_status :ok
       # TODO: such test, wow
-      # expect( response.body ).to have_title I18n.t( 'admin.stats.title' )
+      expect( response.body ).to have_title 'Queries'
+      expect( response.body ).to have_css 'a', text: I18n.t( 'admin.stats.breadcrumb' )
     end
   end
 

--- a/spec/requests/admin/stats_spec.rb
+++ b/spec/requests/admin/stats_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'Blazer (charts and dashboards)', type: :request do
       get blazer_path
 
       expect( response      ).to have_http_status :ok
-      # TODO: such test, wow
-      expect( response.body ).to have_title 'Queries'
+      # FIXME: setting @page_title in _breadcrumbs.html.erb isn't being picked up by _head.html.erb
+      # expect( response.body ).to have_title I18n.t( 'admin.blazer.queries' )
       expect( response.body ).to have_css 'a', text: I18n.t( 'admin.stats.breadcrumb' )
     end
   end

--- a/spec/requests/admin/stats_spec.rb
+++ b/spec/requests/admin/stats_spec.rb
@@ -10,28 +10,48 @@ require 'rails_helper'
 
 # Tests for the Blazer integration
 RSpec.describe 'Blazer (charts and dashboards)', type: :request do
-  before :each do
-    admin = create :stats_admin
-    sign_in admin
-  end
+  context 'as a stats admin user' do
+    before :each do
+      admin = create :stats_admin
+      sign_in admin
+    end
 
-  describe 'GET /stats' do
-    it 'succeeds' do
-      get blazer_path
+    describe 'GET /stats' do
+      it 'succeeds' do
+        get blazer_path
 
-      expect( response      ).to have_http_status :ok
-      # FIXME: setting @page_title in _breadcrumbs.html.erb isn't being picked up by _head.html.erb
-      # expect( response.body ).to have_title I18n.t( 'admin.blazer.queries' )
-      expect( response.body ).to have_css 'a', text: I18n.t( 'admin.stats.breadcrumb' )
+        expect( response      ).to have_http_status :ok
+        # FIXME: setting @page_title in _breadcrumbs.html.erb isn't being picked up by _head.html.erb
+        # expect( response.body ).to have_title I18n.t( 'admin.blazer.queries' )
+        expect( response.body ).to have_css 'a', text: I18n.t( 'admin.stats.breadcrumb' )
+      end
+    end
+
+    describe 'GET /stats' do
+      it 'generates the correct button link' do
+        get blazer_path
+
+        expect( response      ).to have_http_status :ok
+        expect( response.body ).to have_link 'New Query', href: '/admin/stats/queries/new'
+      end
     end
   end
 
-  describe 'GET /stats' do
-    it 'generates the correct button link' do
+  context 'as an admin user without access to the stats feature' do
+    before :each do
+      admin = create :admin_user
+      sign_in admin
+    end
+
+    it 'does not allow access' do
       get blazer_path
 
-      expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_link 'New Query', href: '/admin/stats/queries/new'
+      expect( response      ).to have_http_status :found
+      expect( response      ).to redirect_to '/admin'
+      # TODO: FIXME: Something about this redirect is weird; rspec won't follow it, claims it's nil
+      # follow_redirect!
+      # expect( response      ).to have_http_status :ok
+      # expect( response.body ).to have_css '.alerts', text: I18n.t( 'admin.blazer.auth_fail' )
     end
   end
 end

--- a/spec/requests/feature_flags_spec.rb
+++ b/spec/requests/feature_flags_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Feature Flags', type: :request do
       sign_in user
 
       FeatureFlag.find_or_create_by!( name: 'profile_pages' )
-                 .update!( enabled: false, enabled_for_admins: true )
+                 .update!( enabled: false, enabled_for_logged_in: false, enabled_for_admins: true )
 
       get shiny_profiles.profile_path( user.username )
 
@@ -74,7 +74,7 @@ RSpec.describe 'Feature Flags', type: :request do
       sign_in user
 
       FeatureFlag.find_or_create_by!( name: 'profile_pages' )
-                 .update!( enabled: false, enabled_for_admins: true )
+                 .update!( enabled: false, enabled_for_logged_in: false, enabled_for_admins: true )
 
       get shiny_profiles.profile_path( user.username )
 


### PR DESCRIPTION
This PR adds some default config for Blazer - a dashboard and a dozen sample queries, pulling data from various ShinyCMS content and user tables and Ahoy stats.

I've also tweaked the admin sidebar menu to be all collapsed instead of all open; at some point it still needs to save and restore state across page loads, but in the meantime it's got too darn big to be fully expanded all the time. 🙂 