### PR TITLE
Ignore blatant spammers

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -115,7 +115,7 @@ class DiscussionsController < MainController
     return author if strong_params[ :author_email ].blank?
 
     recipient = EmailRecipient.find_or_initialize_by( email: strong_params[ :author_email ] )
-    author.update!( email_recipient: recipient )
+    author.email_recipient = recipient
     author
   end
 

--- a/spec/requests/discussions_spec.rb
+++ b/spec/requests/discussions_spec.rb
@@ -247,24 +247,31 @@ RSpec.describe 'Discussions/Comments', type: :request do
       FeatureFlag.enable :akismet_for_comments
       allow_any_instance_of( Akismet::Client ).to receive( :check ).and_return( [ true, true ] )
 
+      name  = Faker::Name.unique.name
+      email = Faker::Internet.unique.email
       title = Faker::Books::CultureSeries.unique.culture_ship
       body  = Faker::Lorem.paragraph
 
-      comment_count = Comment.count
+      comment_count         = Comment.count
+      comment_author_count  = CommentAuthor.count
+      email_recipient_count = EmailRecipient.count
 
       post discussion_path( @discussion ), params: {
         comment: {
+          author_name: name,
+          author_email: email,
           title: title,
           body: body
         }
       }
 
-      expect( response ).to have_http_status :ok
-
-      expect( Comment.count ).to eq comment_count
-
+      expect( response      ).to have_http_status :ok
       expect( response.body ).not_to have_css '.notices', text: I18n.t( 'discussions.add_comment.success' )
       expect( response.body ).not_to have_css 'h2', text: title
+
+      expect( Comment.count        ).to eq comment_count
+      expect( CommentAuthor.count  ).to eq comment_author_count
+      expect( EmailRecipient.count ).to eq email_recipient_count
     end
   end
 


### PR DESCRIPTION
A slight mis-use of ActiveRecord meant that we were still creating CommentAuthor records (and EmailRecipient, and hence confirmation email jobs) even if the actual comment was so obviously spam that we didn't bother to put it in the database itself.