### PR TITLE
Finish separating user profiles from user accounts

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -71,7 +71,7 @@ class MainController < ApplicationController
 
     return admin_path if resource.can? :view_admin_area
 
-    return shiny_profiles.profile_path( resource.username ) if feature_enabled?( :profile_pages )
+    return shiny_profiles.profile_path( resource.username ) if feature_enabled?( :user_profiles )
 
     root_path
   end

--- a/app/models/shiny_plugin.rb
+++ b/app/models/shiny_plugin.rb
@@ -72,13 +72,6 @@ class ShinyPlugin
     loaded_names.include? plugin_name.to_s
   end
 
-  def self.all_loaded?( *plugin_names )
-    plugin_names.each do |name|
-      return false unless loaded? name
-    end
-    true
-  end
-
   def self.with_main_site_helpers
     loaded.select( &:main_site_helper )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,6 @@ class User < ApplicationRecord
   # Instance methods
 
   def name
-    # TODO: FIXME: crossing an architectural boundary here
     return profile.name if ShinyPlugin.loaded?( :ShinyProfiles ) && profile.present?
 
     username

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@
 
 # Model for user accounts (largely powered by Devise)
 class User < ApplicationRecord
-  include ShinySearch::Searchable if ShinyPlugin.loaded? :ShinySearch
   include ShinyEmail
   include ShinyPaging
   include ShinySoftDelete
@@ -22,11 +21,6 @@ class User < ApplicationRecord
 
   # Upvotes AKA 'likes'
   acts_as_voter
-
-  if ShinyPlugin.all_loaded? :ShinySearch, :ShinyProfiles
-    # TODO: all of these except username will be moving into ShinyProfiles::Profile
-    searchable_by :username, :public_name, :public_email, :bio, :website, :location, :postcode
-  end
 
   # Associations
 
@@ -59,11 +53,6 @@ class User < ApplicationRecord
 
   # Virtual attributes
 
-  # User profile pic (powered by ActiveStorage)
-  has_one_attached :profile_pic, dependent: :purge_now
-  # The dependent: :purge_now option is required to avoid an incompatibility issue with soft delete:
-  # https://github.com/ActsAsParanoid/acts_as_paranoid/issues/103
-
   # Allow authenticating by either username or email
   attr_writer :login
 
@@ -71,15 +60,13 @@ class User < ApplicationRecord
     @login || username || email
   end
 
-  # ShinySearch::Searchable expects this to exist
-  def hidden?
-    false
-  end
-
   # Instance methods
 
   def name
-    public_name.presence || username
+    # TODO: FIXME: crossing an architectural boundary here
+    return profile.name if ShinyPlugin.loaded?( :ShinyProfiles ) && profile.present?
+
+    username
   end
 
   def admin?

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -1,7 +1,14 @@
+<% plugin_name = controller.class.name.split('::').first %>
+
 <nav class="breadcrumbs">
   <ol class="breadcrumb border-0 m-0">
     <li class="breadcrumb-item"><%= link_to t( 'home'             ), main_app.root_path  %></li>
+
+    <% if plugin_name == 'ShinyProfiles' %>
     <li class="breadcrumb-item"><%= link_to t( 'admin.breadcrumb' ), main_app.admin_path %></li>
+    <% else %>
+    <li class="breadcrumb-item"><%= link_to t( 'admin.breadcrumb' ), admin_path %></li>
+    <% end %>
 
     <li class="breadcrumb-item">
       <% plugin_name = controller.class.name.split('::').first %>

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -1,7 +1,7 @@
 <nav class="breadcrumbs">
   <ol class="breadcrumb border-0 m-0">
-    <li class="breadcrumb-item"><%= link_to t( 'home'             ), root_path  %></li>
-    <li class="breadcrumb-item"><%= link_to t( 'admin.breadcrumb' ), admin_path %></li>
+    <li class="breadcrumb-item"><%= link_to t( 'home'             ), main_app.root_path  %></li>
+    <li class="breadcrumb-item"><%= link_to t( 'admin.breadcrumb' ), main_app.admin_path %></li>
 
     <li class="breadcrumb-item">
       <% plugin_name = controller.class.name.split('::').first %>

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -6,18 +6,21 @@
     <li class="breadcrumb-item">
       <% plugin_name = controller.class.name.split('::').first %>
 
-      <%# Allow controllers to override their 'section' breadcrumb link %>
-      <% if controller.respond_to? :breadcrumb_link_text_and_path %>
-        <%= link_to *controller.breadcrumb_link_text_and_path %>
-
       <%# ShinyCMS plugins %>
-      <% elsif plugin_loaded? plugin_name %>
-        <%= link_to *plugin_breadcrumb_link_text_and_path( plugin_name, controller_name ) %>
+      <% if plugin_loaded? plugin_name %>
+
+        <%# Allow plugin controllers to override their 'section' breadcrumb link %>
+        <% if controller.respond_to? :breadcrumb_link_text_and_path %>
+          <%= link_to *controller.breadcrumb_link_text_and_path %>
+        <% else %>
+          <%= link_to *plugin_breadcrumb_link_text_and_path( plugin_name, controller_name ) %>
+        <% end %>
 
       <%# Other engines %>
       <% elsif plugin_name == 'Blazer' %>
         <% @page_title = t( "admin.blazer.#{controller_name}.title" ) %>
         <%= link_to t( 'admin.stats.breadcrumb' ), blazer.root_path %>
+
       <% elsif plugin_name == 'RailsEmailPreview' %>
         <%= link_to t( 'rails_email_preview.breadcrumb' ), rails_email_preview.rep_root_path %>
 

--- a/app/views/admin/includes/_breadcrumbs.html.erb
+++ b/app/views/admin/includes/_breadcrumbs.html.erb
@@ -1,14 +1,7 @@
-<% plugin_name = controller.class.name.split('::').first %>
-
 <nav class="breadcrumbs">
   <ol class="breadcrumb border-0 m-0">
-    <li class="breadcrumb-item"><%= link_to t( 'home'             ), main_app.root_path  %></li>
-
-    <% if plugin_name == 'ShinyProfiles' %>
-    <li class="breadcrumb-item"><%= link_to t( 'admin.breadcrumb' ), main_app.admin_path %></li>
-    <% else %>
+    <li class="breadcrumb-item"><%= link_to t( 'home'             ), main_app.root_path %></li>
     <li class="breadcrumb-item"><%= link_to t( 'admin.breadcrumb' ), admin_path %></li>
-    <% end %>
 
     <li class="breadcrumb-item">
       <% plugin_name = controller.class.name.split('::').first %>

--- a/app/views/admin/includes/_user_menu.html.erb
+++ b/app/views/admin/includes/_user_menu.html.erb
@@ -12,11 +12,16 @@
     </a>
     <div class="dropdown-menu dropdown-menu-right pt-0">
       <div class="dropdown-header bg-light py-2"><strong><%= current_user.name %></strong></div>
+      <% if plugin_loaded? :ShinyProfiles && current_user.profile.present? %>
       <a class="dropdown-item" href="<%= shiny_profiles.profile_path( current_user.username ) %>">
         <i class="cil-user user-menu-icon"></i> <%= t( 'shiny_profiles.view_profile' ) %>
       </a>
-      <a class="dropdown-item" href="<%= main_app.edit_user_registration_path( current_user.username ) %>">
+      <a class="dropdown-item" href="<%= shiny_profiles.edit_profile_path( current_user.profile ) %>">
         <i class="cil-pencil user-menu-icon"></i> <%= t( 'shiny_profiles.edit_profile' ) %>
+      </a>
+      <% end %>
+      <a class="dropdown-item" href="<%= main_app.edit_user_registration_path( current_user.username ) %>">
+        <i class="cil-pencil user-menu-icon"></i> <%= t( 'admin.users.edit.title' ) %>
       </a>
       <div class="dropdown-divider"></div>
       <a class="dropdown-item" href="<%= main_app.site_settings_path %>">

--- a/app/views/admin/includes/_user_menu.html.erb
+++ b/app/views/admin/includes/_user_menu.html.erb
@@ -2,9 +2,9 @@
 <ul class="c-header-nav ml-auto mr-4">
   <li class="c-header-nav-item dropdown">
     <a class="c-header-nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-      <% if current_user.profile_pic.attached? %>
+      <% if current_user.profile&.profile_pic&.attached? %>
       <div class="c-avatar">
-        <%= image_tag url_for( current_user.profile_pic.variant( resize: '36x36!' ) ), alt: current_user.name, class: 'c-avatar-img' %>
+        <%= image_tag url_for( current_user.profile.profile_pic.variant( resize: '36x36!' ) ), alt: current_user.name, class: 'c-avatar-img' %>
       </div>
       <% else %>
       <i class="cil-user user-menu-icon"></i>

--- a/app/views/admin/menu/_consent_versions.html.erb
+++ b/app/views/admin/menu/_consent_versions.html.erb
@@ -3,9 +3,9 @@
   <%= render_admin_menu_section( t( 'admin.consent_versions.menu' ), 'check' ) do %>
 
     <%= render_admin_menu_item(
-        t( 'admin.consent_versions.index.title' ), consent_versions_path, 'check-alt' ) %>
+        t( 'admin.consent_versions.index.title' ), main_app.consent_versions_path, 'check-alt' ) %>
 
     <%= render_admin_menu_item_if( current_user.can?( :add, :consent_versions ),
-        t( 'admin.consent_versions.new.title' ), new_consent_version_path, 'plus' ) %>
+        t( 'admin.consent_versions.new.title' ), main_app.new_consent_version_path, 'plus' ) %>
 
   <% end %>

--- a/app/views/admin/menu/_email.html.erb
+++ b/app/views/admin/menu/_email.html.erb
@@ -6,6 +6,6 @@
         t( 'admin.email_recipients.menu' ), main_app.email_recipients_path, 'envelope-closed' ) %>
 
     <%= render_admin_menu_item_if( current_user.can?( :list, :mailer_previews ),
-        t( 'rails_email_preview.menu' ), rails_email_preview_path, 'envelope-letter' ) %>
+        t( 'rails_email_preview.menu' ), main_app.rails_email_preview_path, 'envelope-letter' ) %>
 
   <% end %>

--- a/app/views/admin/menu/_other.html.erb
+++ b/app/views/admin/menu/_other.html.erb
@@ -5,6 +5,6 @@
     <% end %>
 
     <%= render_admin_menu_item_if( current_user.can?( :list, :spam_comments ),
-        t( 'admin.comments.menu' ), comments_path, 'trash' ) %>
+        t( 'admin.comments.menu' ), main_app.comments_path, 'trash' ) %>
 
   <% end %>

--- a/app/views/admin/menu/_settings.html.erb
+++ b/app/views/admin/menu/_settings.html.erb
@@ -4,9 +4,9 @@
   <%= render_admin_menu_section( t( 'admin.site_settings.menu' ), 'settings' ) do %>
 
     <%= render_admin_menu_item_if( current_user.can?( :list, :settings ),
-        t( 'admin.site_settings.index.title' ), admin_site_settings_path, 'settings' ) %>
+        t( 'admin.site_settings.index.title' ), main_app.admin_site_settings_path, 'settings' ) %>
 
     <%= render_admin_menu_item_if( current_user.can?( :list, :feature_flags ),
-        t( 'admin.feature_flags.menu' ), feature_flags_path, 'toggle-off' ) %>
+        t( 'admin.feature_flags.menu' ), main_app.feature_flags_path, 'toggle-off' ) %>
 
   <% end %>

--- a/app/views/admin/menu/_sidekiq_web.html.erb
+++ b/app/views/admin/menu/_sidekiq_web.html.erb
@@ -1,3 +1,3 @@
  <% return unless sidekiq_web_enabled? && current_user.can?( :manage_sidekiq_jobs ) %>
 
-  <%= render_admin_menu_item( t( 'admin.sidekiq_web.menu' ), sidekiq_web_path, 'applications' ) %>
+  <%= render_admin_menu_item( t( 'admin.sidekiq_web.menu' ), main_app.sidekiq_web_path, 'applications' ) %>

--- a/app/views/admin/menu/_stats.html.erb
+++ b/app/views/admin/menu/_stats.html.erb
@@ -6,12 +6,12 @@
   <%= render_admin_menu_section( t( 'admin.stats.menu' ), 'chart' ) do %>
 
     <%= render_admin_menu_item_if( current_user.can?( :view_web, :stats ),
-        t( 'admin.web_stats.menu' ), web_stats_path, 'bar-chart' ) %>
+        t( 'admin.web_stats.menu' ), main_app.web_stats_path, 'bar-chart' ) %>
 
     <%= render_admin_menu_item_if( current_user.can?( :view_email, :stats ),
-        t( 'admin.email_stats.menu' ), email_stats_path, 'chart-pie' ) %>
+        t( 'admin.email_stats.menu' ), main_app.email_stats_path, 'chart-pie' ) %>
 
     <%= render_admin_menu_item_if( current_user.can?( :make_charts, :stats ),
-        t( 'admin.blazer.menu' ), blazer_path, 'chart-line' ) %>
+        t( 'admin.blazer.menu' ), main_app.blazer_path, 'chart-line' ) %>
 
   <% end %>

--- a/app/views/admin/menu/_users.html.erb
+++ b/app/views/admin/menu/_users.html.erb
@@ -3,9 +3,9 @@
   <%= render_admin_menu_section( t( 'admin.users.menu' ), 'people' ) do %>
 
     <%= render_admin_menu_item(
-        t( 'admin.users.index.title' ), users_path, 'people' ) %>
+        t( 'admin.users.index.title' ), main_app.users_path, 'people' ) %>
 
     <%= render_admin_menu_item_if( current_user.can?( :add, :users ),
-        t( 'admin.users.new.title' ), new_user_path, 'user-follow' ) %>
+        t( 'admin.users.new.title' ), main_app.new_user_path, 'user-follow' ) %>
 
   <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -6,46 +6,13 @@
     <br><%= f.text_field :username %>
   </p>
   <p>
-    <%= f.label :public_name %>
-    <br><%= f.text_field :public_name %>
-  </p>
-
-  <p>
     <%= f.label :email %>
     <br><%= f.text_field :email %>
   </p>
   <p>
-    <%= f.label :public_email %>
-    <br><%= f.text_field :public_email %>
-  </p>
-
-  <p>
     <%= f.label :password %>
     <br><%= f.text_field :password %>
   </p>
-
-  <p>
-    <%= f.label :profile_pic %>
-    <br><%= f.file_field :profile_pic %>
-    <% if @user.profile_pic.attached? %>
-    <br><%= image_tag url_for( @user.profile_pic.variant( resize: '200x200!' ) ), class: 'user_icon' %>
-    <% end %>
-  </p>
-
-  <p>
-    <%= f.label :bio %>
-    <br><%= f.text_area :bio %>
-  </p>
-
-  <p>
-    <%= f.label :location %>
-    <br><%= f.text_field :location %>
-  </p>
-  <p>
-    <%= f.label :postcode %>
-    <br><%= f.text_field :postcode, class: 'textshort' %>
-  </p>
-
   <p>
     <%= f.label :admin_notes %>
     <br><%= f.text_area :admin_notes %>

--- a/app/views/shinycms/devise/registrations/edit.html.erb
+++ b/app/views/shinycms/devise/registrations/edit.html.erb
@@ -17,40 +17,9 @@
       <%= f.email_field :email, autofocus: true, autocomplete: 'email' %>
     </div>
 
-    <div class="field">
-      <%= f.label :public_name %><br>
-      <%= f.text_field :public_name %>
-    </div>
-    <div class="field">
-      <%= f.label :public_email %>
-      <br><%= f.text_field :public_email %>
-    </div>
-
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
-
-    <div class="field">
-      <%= f.label :profile_pic %>
-      <br><%= f.file_field :profile_pic %>
-      <% if resource.profile_pic.attached? %>
-      <br><%= image_tag url_for( resource.profile_pic.variant( resize: '200x200!' ) ), class: 'user_icon' %>
-      <% end %>
-    </div>
-
-    <div class="field">
-      <%= f.label :bio %>
-      <br><%= f.text_area :bio %>
-    </div>
-
-    <div class="field">
-      <%= f.label :location %>
-      <br><%= f.text_field :location %>
-    </div>
-    <div class="field">
-      <%= f.label :postcode %>
-      <br><%= f.text_field :postcode %>
-    </div>
 
     <div class="field">
       <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br>
@@ -72,7 +41,7 @@
     </div>
 
     <div class="actions">
-      <%= f.submit "Update" %>
+      <%= f.submit t( 'update' ) %>
     </div>
   <% end %>
 </section>
@@ -82,5 +51,5 @@
 
   <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
-  <%= link_to "Back", :back %>
+  <%= link_to t( 'back' ), :back %>
 </section>

--- a/app/views/shinycms/devise/registrations/new.html.erb
+++ b/app/views/shinycms/devise/registrations/new.html.erb
@@ -1,7 +1,9 @@
+<%= @page_title = t( '.title' ) %>
+
 <section>
   <header>
     <h2>
-      Register
+      <%= @page_title %>
     </h2>
   </header>
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -76,26 +76,14 @@ search:
     - app/models
     - app/views
     - app/views/shinycms
+    # Check for usage in the plugin views and controllers too
+    <% plugin_names = Dir[ 'plugins/*' ].sort.collect { |plugin_name| plugin_name.sub( 'plugins/', '' ) } %>
+    <% plugin_names.each do |plugin_name| %>
+    - <%= "plugins/#{plugin_name}/app/controllers" %>
+    - <%= "plugins/#{plugin_name}/app/views" %>
+    <% end %>
     # FIXME
-    - plugins/ShinyAccess/app/controllers
-    - plugins/ShinyAccess/app/views
-    - plugins/ShinyBlog/app/controllers
-    - plugins/ShinyBlog/app/views
-    - plugins/ShinyForms/app/controllers
-    - plugins/ShinyForms/app/views
-    - plugins/ShinyInserts/app/controllers
-    - plugins/ShinyInserts/app/views
-    - plugins/ShinyLists/app/controllers
-    - plugins/ShinyLists/app/views
-    - plugins/ShinyNews/app/controllers
-    - plugins/ShinyNews/app/views
-    - plugins/ShinyNewsletters/app/views
-    - plugins/ShinyNewsletters/app/controllers
-    - plugins/ShinyPages/app/controllers
     - plugins/ShinyPages/app/models
-    - plugins/ShinyPages/app/views
-    - plugins/ShinySearch/app/controllers
-    - plugins/ShinySearch/app/views
 
   ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
   ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
   add: Add
   edit: Edit
   post: Post
+  back: Back
   show: Show
   hide: Hide
   lock: Lock
@@ -70,6 +71,11 @@ en:
 
 
   # ========== ( Main Site ) ==========
+
+  devise:
+    registrations:
+      new:
+        title: Create user account
 
   discussions:
     anonymous: Anonymous

--- a/db/demo_data.rb
+++ b/db/demo_data.rb
@@ -176,7 +176,7 @@ Comment.create!([
 ])
 
 ActiveStorage::Attachment.create!([
-  {id: 1, name: "profile_pic", record_type: "User", record_id: 1, blob_id: 1},
+  {id: 1, name: "profile_pic", record_type: "ShinyProfiles::Profile", record_id: 1, blob_id: 1},
   {id: 2, name: "image", record_type: "ShinyPages::PageElement", record_id: 4, blob_id: 2},
   {id: 3, name: "image", record_type: "ShinyPages::PageElement", record_id: 5, blob_id: 3},
   {id: 4, name: "image", record_type: "ShinyPages::PageElement", record_id: 8, blob_id: 4},

--- a/db/migrate/20201130234759_create_shiny_profiles_tables.shiny_profiles.rb
+++ b/db/migrate/20201130234759_create_shiny_profiles_tables.shiny_profiles.rb
@@ -1,0 +1,32 @@
+# This migration comes from shiny_profiles (originally 20201128224232)
+class CreateShinyProfilesTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shiny_profiles_profiles do |t|
+      t.string :public_name
+      t.string :public_email
+      t.text :bio
+      t.string :location
+      t.string :postcode
+
+      t.boolean :show_on_site, null: false, default: true
+      t.boolean :show_in_gallery, null: false, default: true
+      t.boolean :show_to_unauthenticated, null: false, default: true
+
+      t.belongs_to :user, foreign_key: true, null: false
+
+      t.timestamps
+      t.datetime :deleted_at, precision: 6, index: true
+    end
+
+    create_table :shiny_profiles_links do |t|
+      t.string :name, null: false
+      t.string :url, null: false
+      t.integer :position
+
+      t.belongs_to :profile, foreign_key: { to_table: :shiny_profiles_profiles }, null: false
+
+      t.timestamps
+      t.datetime :deleted_at, precision: 6, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 
-ActiveRecord::Schema.define(version: 2020_11_21_073328) do
+ActiveRecord::Schema.define(version: 2020_11_30_234759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -577,6 +577,35 @@ ActiveRecord::Schema.define(version: 2020_11_21_073328) do
     t.index ["deleted_at"], name: "index_shiny_pages_templates_on_deleted_at"
   end
 
+  create_table "shiny_profiles_links", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "url", null: false
+    t.integer "position"
+    t.bigint "profile_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at", precision: 6
+    t.index ["deleted_at"], name: "index_shiny_profiles_links_on_deleted_at"
+    t.index ["profile_id"], name: "index_shiny_profiles_links_on_profile_id"
+  end
+
+  create_table "shiny_profiles_profiles", force: :cascade do |t|
+    t.string "public_name"
+    t.string "public_email"
+    t.text "bio"
+    t.string "location"
+    t.string "postcode"
+    t.boolean "show_on_site", default: true, null: false
+    t.boolean "show_in_gallery", default: true, null: false
+    t.boolean "show_to_unauthenticated", default: true, null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at", precision: 6
+    t.index ["deleted_at"], name: "index_shiny_profiles_profiles_on_deleted_at"
+    t.index ["user_id"], name: "index_shiny_profiles_profiles_on_user_id"
+  end
+
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
     t.string "taggable_type"
@@ -698,6 +727,8 @@ ActiveRecord::Schema.define(version: 2020_11_21_073328) do
   add_foreign_key "shiny_pages_sections", "shiny_pages_pages", column: "default_page_id"
   add_foreign_key "shiny_pages_sections", "shiny_pages_sections", column: "section_id"
   add_foreign_key "shiny_pages_template_elements", "shiny_pages_templates", column: "template_id"
+  add_foreign_key "shiny_profiles_links", "shiny_profiles_profiles", column: "profile_id"
+  add_foreign_key "shiny_profiles_profiles", "users"
   add_foreign_key "taggings", "tags"
   add_foreign_key "user_capabilities", "capabilities"
   add_foreign_key "user_capabilities", "users"

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -8,6 +8,8 @@
 
 * Delete ahoy and session data when Akismet reports blatant spam? (make configurable)
 
+* Finish adding support for links on user profiles
+
 ## Features the Perl version has, which the Ruby version doesn't. Yet. :)
 
 ### Small-ish

--- a/plugins/ShinyProfiles/Gemfile.lock
+++ b/plugins/ShinyProfiles/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shiny_profiles (20.10)
+    shiny_profiles (20.11)
       pg (>= 0.18, < 2.0)
       rails (~> 6.0.3, >= 6.0.3.4)
 

--- a/plugins/ShinyProfiles/app/controllers/shiny_profiles/admin/profiles_controller.rb
+++ b/plugins/ShinyProfiles/app/controllers/shiny_profiles/admin/profiles_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+module ShinyProfiles
+  # Controller for admin updates to user profiles - part of the ShinyProfiles plugin for ShinyCMS
+  class Admin::ProfilesController < AdminController
+    def edit
+      @profile = Profile.find( params[:id] )
+      authorize @profile
+    end
+
+    def update
+      @profile = Profile.find( params[:id] )
+      authorize @profile
+
+      if @profile.update( strong_params )
+        redirect_to admin_edit_profile_path( @profile ), notice: t( '.success' )
+      else
+        flash.now[ :alert ] = t( '.failure' )
+        render action: :edit
+      end
+    end
+
+    private
+
+    def strong_params
+      params.require( :profile ).permit(
+        :public_name, :public_email, :profile_pic, :bio, :location, :postcode
+      )
+    end
+  end
+end

--- a/plugins/ShinyProfiles/app/controllers/shiny_profiles/admin/profiles_controller.rb
+++ b/plugins/ShinyProfiles/app/controllers/shiny_profiles/admin/profiles_controller.rb
@@ -18,12 +18,9 @@ module ShinyProfiles
       @profile = Profile.find( params[:id] )
       authorize @profile
 
-      if @profile.update( strong_params )
-        redirect_to admin_edit_profile_path( @profile ), notice: t( '.success' )
-      else
-        flash.now[ :alert ] = t( '.failure' )
-        render action: :edit
-      end
+      flash[ :notice ] = t( '.success' ) if @profile.update( strong_params )
+
+      redirect_to admin_edit_profile_path( @profile )
     end
 
     private

--- a/plugins/ShinyProfiles/app/controllers/shiny_profiles/admin_controller.rb
+++ b/plugins/ShinyProfiles/app/controllers/shiny_profiles/admin_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+module ShinyProfiles
+  # Base controller for admin features of ShinyProfiles plugin for ShinyCMS
+  # Inherits from ShinyCMS AdminController
+  class AdminController < ::AdminController
+    helper Rails.application.routes.url_helpers
+  end
+end

--- a/plugins/ShinyProfiles/app/controllers/shiny_profiles/profiles_controller.rb
+++ b/plugins/ShinyProfiles/app/controllers/shiny_profiles/profiles_controller.rb
@@ -17,8 +17,15 @@ module ShinyProfiles
     end
 
     def show
-      @user_profile = User.readonly.find_by( username: params[ :username ] )
-      return if @user_profile.present?
+      @profile = User.readonly.find_by( username: params[ :username ] )&.profile
+      return if @profile.present?
+
+      render 'errors/404', status: :not_found
+    end
+
+    def edit
+      @profile = User.readonly.find_by( username: params[ :username ] )&.profile
+      return if @profile.present?
 
       render 'errors/404', status: :not_found
     end
@@ -34,7 +41,7 @@ module ShinyProfiles
     private
 
     def check_feature_flags
-      enforce_feature_flags :profile_pages
+      enforce_feature_flags :user_profiles
     end
   end
 end

--- a/plugins/ShinyProfiles/app/models/shiny_profiles/link.rb
+++ b/plugins/ShinyProfiles/app/models/shiny_profiles/link.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+module ShinyProfiles
+  # Model for user profile pages (and related features)
+  class Link < ApplicationRecord
+    include ShinySoftDelete
+
+    # Associations
+
+    belongs_to :profile, inverse_of: :links
+
+    # Validations
+
+    validates :profile, presence: true
+    validates :name,    presence: true
+    validates :url,     presence: true
+  end
+end

--- a/plugins/ShinyProfiles/app/models/shiny_profiles/profile.rb
+++ b/plugins/ShinyProfiles/app/models/shiny_profiles/profile.rb
@@ -17,6 +17,10 @@ module ShinyProfiles
 
     belongs_to :user
 
+    has_many :links, -> { order( :position ) }, inverse_of: :profile, dependent: :destroy
+
+    accepts_nested_attributes_for :links
+
     # User profile pic (powered by ActiveStorage)
     has_one_attached :profile_pic, dependent: :purge_now
     # The dependent: :purge_now option is required to avoid an incompatibility issue with soft delete:

--- a/plugins/ShinyProfiles/app/models/shiny_profiles/profile.rb
+++ b/plugins/ShinyProfiles/app/models/shiny_profiles/profile.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+module ShinyProfiles
+  # Model for user profile pages (and related features)
+  class Profile < ApplicationRecord
+    include ShinySearch::Searchable if ShinyPlugin.loaded? :ShinySearch
+    include ShinyShowHide
+    include ShinySoftDelete
+
+    # Associations
+
+    belongs_to :user
+
+    # User profile pic (powered by ActiveStorage)
+    has_one_attached :profile_pic, dependent: :purge_now
+    # The dependent: :purge_now option is required to avoid an incompatibility issue with soft delete:
+    # https://github.com/ActsAsParanoid/acts_as_paranoid/issues/103
+
+    # Validations
+
+    validates :user, presence: true, uniqueness: true
+
+    # Get username and email for Profile via the associated User model
+
+    delegate :username, to: :user
+    delegate :email,    to: :user
+
+    # Plugins
+
+    searchable_by :username, :public_name, :public_email, :bio, :location, :postcode if ShinyPlugin.loaded? :ShinySearch
+
+    # Instance methods
+
+    def name
+      public_name.presence || username
+    end
+  end
+end
+
+::User.has_one :profile, inverse_of: :user, class_name: 'ShinyProfiles::Profile', dependent: :destroy

--- a/plugins/ShinyProfiles/app/policies/shiny_profiles/profile_policy.rb
+++ b/plugins/ShinyProfiles/app/policies/shiny_profiles/profile_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+module ShinyProfiles
+  # Pundit policy for user profiles - part of the ShinyProfiles plugin for ShinyCMS
+  class ProfilePolicy
+    attr_reader :this_user, :record
+
+    def initialize( this_user, record )
+      @this_user = this_user
+      @record = record
+    end
+
+    def edit?
+      @this_user.can? :edit, :users
+    end
+
+    def update?
+      edit?
+    end
+  end
+end

--- a/plugins/ShinyProfiles/app/views/shiny_profiles/admin/profiles/edit.html.erb
+++ b/plugins/ShinyProfiles/app/views/shiny_profiles/admin/profiles/edit.html.erb
@@ -1,18 +1,9 @@
-<% @page_title = t( '.title', name: @profile.name ) %>
+<% @page_title = t( '.title' ) %>
 
-<%= form_for @profile, url: shiny_profiles.edit_profile_path( @profile ), method: :put do |f| %>
-  <p>
-    <%= f.label :username %>
-    <br><%= f.text_field :username, disabled: true %>
-  </p>
+<%= form_for @profile, url: shiny_profiles.admin_profile_path( @profile ), method: :put do |f| %>
   <p>
     <%= f.label :public_name %>
     <br><%= f.text_field :public_name %>
-  </p>
-
-  <p>
-    <%= f.label :email %>
-    <br><%= f.text_field :email %>
   </p>
   <p>
     <%= f.label :public_email %>

--- a/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/_admin.html.erb
+++ b/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/_admin.html.erb
@@ -1,4 +1,4 @@
-<% if current_user_can?( :view_admin_notes, :users ) && @user_profile.admin_notes.present? %>
+<% if current_user_can?( :view_admin_notes, :users ) && @profile.user.admin_notes.present? %>
 <section>
   <header>
     <h3>
@@ -6,6 +6,6 @@
     </h3>
   </header>
 
-  <%= simple_format @user_profile.admin_notes %>
+  <%= simple_format @profile.user.admin_notes %>
 </section>
 <% end %>

--- a/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/_private.html.erb
+++ b/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/_private.html.erb
@@ -1,4 +1,4 @@
-<% if @user_profile == current_user %>
+<% if @profile == current_user %>
 <section>
   <header>
     <h3>
@@ -7,11 +7,11 @@
   </header>
 
   <p>
-    Account created: <%= display_date_at_time( @user_profile.created_at ) %>
+    Account created: <%= display_date_at_time( @profile.created_at ) %>
   </p>
   <p>
-    Last login: <%= display_date_at_time( @user_profile.last_sign_in_at ) %>
-    from <%= @user_profile.last_sign_in_ip_was %>
+    Last login: <%= display_date_at_time( @profile.last_sign_in_at ) %>
+    from <%= @profile.last_sign_in_ip_was %>
   </p>
 </section>
 <% end %>

--- a/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/_public.html.erb
+++ b/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/_public.html.erb
@@ -1,25 +1,25 @@
 <section>
-  <% if @user_profile.profile_pic.attached? %>
-  <%= image_tag url_for( @user_profile.profile_pic.variant( resize_to_limit: [400,400] ) ), class: 'user-profile-pic' %>
+  <% if @profile.profile_pic.attached? %>
+  <%= image_tag url_for( @profile.profile_pic.variant( resize_to_limit: [400,400] ) ), class: 'user-profile-pic' %>
   <% end %>
 
   <header>
     <h2>
-      <%= @user_profile.name %>
+      <%= @profile.name %>
     </h2>
   </header>
 
-  <% if @user_profile.bio.present? %>
-  <%= simple_format @user_profile.bio %>
+  <% if @profile.bio.present? %>
+  <%= simple_format @profile.bio %>
   <% end %>
 
   <br>
 
   <p>
-    Joined on <%= display_date( @user_profile.created_at ) %>
+    Joined on <%= display_date( @profile.created_at ) %>
   </p>
 
-  <% if @user_profile.profile_pic.present? %>
+  <% if @profile.profile_pic.present? %>
   <div class="clear-both"></div>
   <% end %>
 </section>

--- a/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/edit.html.erb
+++ b/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/edit.html.erb
@@ -1,0 +1,47 @@
+<% @page_title = t( '.title', name: @profile.name ) %>
+
+<%= form_for @profile, url: shiny_profiles.edit_profile_path( @profile ), method: :put do |f| %>
+  <p>
+    <%= f.label :username %>
+    <br><%= f.text_field :username disabled: true %>
+  </p>
+  <p>
+    <%= f.label :public_name %>
+    <br><%= f.text_field :public_name %>
+  </p>
+
+  <p>
+    <%= f.label :email %>
+    <br><%= f.text_field :email %>
+  </p>
+  <p>
+    <%= f.label :public_email %>
+    <br><%= f.text_field :public_email %>
+  </p>
+
+  <p>
+    <%= f.label :profile_pic %>
+    <br><%= f.file_field :profile_pic %>
+    <% if @profile.profile_pic.attached? %>
+    <br><%= image_tag url_for( @profile.profile_pic.variant( resize: '200x200!' ) ), class: 'user_icon' %>
+    <% end %>
+  </p>
+
+  <p>
+    <%= f.label :bio %>
+    <br><%= f.text_area :bio %>
+  </p>
+
+  <p>
+    <%= f.label :location %>
+    <br><%= f.text_field :location %>
+  </p>
+  <p>
+    <%= f.label :postcode %>
+    <br><%= f.text_field :postcode, class: 'textshort' %>
+  </p>
+
+  <p class="top-margin">
+    <%= submit_tag t( 'update' ) %>
+  </p>
+<% end %>

--- a/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/show.html.erb
+++ b/plugins/ShinyProfiles/app/views/shiny_profiles/profiles/show.html.erb
@@ -1,4 +1,4 @@
-<% @page_title = @user_profile.name %>
+<% @page_title = @profile.name %>
 
 <%= render partial: 'public' %>
 

--- a/plugins/ShinyProfiles/app/views/shiny_profiles/search/result/shiny_profiles/_profile.html.erb
+++ b/plugins/ShinyProfiles/app/views/shiny_profiles/search/result/shiny_profiles/_profile.html.erb
@@ -1,5 +1,5 @@
 <%= link_to result.name, shiny_profiles.profile_path( result.username ) %>
 <small><i>
-  account created <%= display_date( result.created_at ) %>
+  profile created <%= display_date( result.created_at ) %>
   <% if result.updated_at > result.created_at %>(last updated on <%= display_date( result.updated_at ) %>)<% end %>
 </i></small>

--- a/plugins/ShinyProfiles/config/locales/en.yml
+++ b/plugins/ShinyProfiles/config/locales/en.yml
@@ -16,3 +16,11 @@ en:
     profiles:
       edit:
         title: "Editing %{name}'s profile"
+
+    admin:
+      profiles:
+        edit:
+          title: Edit user profile
+        update:
+          success: User profile details updated
+          failure: Failed to update user profile details

--- a/plugins/ShinyProfiles/config/locales/en.yml
+++ b/plugins/ShinyProfiles/config/locales/en.yml
@@ -8,8 +8,11 @@
 
 en:
   feature_flags:
-    profile_pages: Profile pages
+    user_profiles: User profile pages
 
   shiny_profiles:
     view_profile: View your profile
     edit_profile: Edit your profile
+    profiles:
+      edit:
+        title: "Editing %{name}'s profile"

--- a/plugins/ShinyProfiles/config/locales/en.yml
+++ b/plugins/ShinyProfiles/config/locales/en.yml
@@ -19,8 +19,8 @@ en:
 
     admin:
       profiles:
+        breadcrumb: User profiles
         edit:
           title: Edit user profile
         update:
           success: User profile details updated
-          failure: Failed to update user profile details

--- a/plugins/ShinyProfiles/config/routes.rb
+++ b/plugins/ShinyProfiles/config/routes.rb
@@ -9,14 +9,17 @@
 ShinyProfiles::Engine.routes.draw do
   scope format: false do
     # Main site
-    get 'profiles',           to: 'profiles#index'
-    get 'profile/:username',  to: 'profiles#show', as: :profile,
-                              constraints: { username: User::USERNAME_REGEX }
-    get 'profile',            to: 'profiles#profile_redirect', as: :profile_redirect
+    get 'profiles',               to: 'profiles#index'
+    get 'profile',                to: 'profiles#profile_redirect', as: :profile_redirect
+    get 'profile/:username',      to: 'profiles#show', as: :profile,
+                                  constraints: { username: User::USERNAME_REGEX }
+    get 'profile/:username/edit', to: 'profiles#edit', as: :edit_profile,
+                                  constraints: { username: User::USERNAME_REGEX }
 
     # Admin area
     scope path: 'admin', module: 'admin' do
-      put 'profiles/:id', to: 'profiles#update', as: :user_profile
+      get 'profiles/:id/edit', to: 'profiles#edit',   as: :admin_edit_profile
+      put 'profiles/:id',      to: 'profiles#update', as: :admin_profile
     end
   end
 end

--- a/plugins/ShinyProfiles/config/routes.rb
+++ b/plugins/ShinyProfiles/config/routes.rb
@@ -13,5 +13,10 @@ ShinyProfiles::Engine.routes.draw do
     get 'profile/:username',  to: 'profiles#show', as: :profile,
                               constraints: { username: User::USERNAME_REGEX }
     get 'profile',            to: 'profiles#profile_redirect', as: :profile_redirect
+
+    # Admin area
+    scope path: 'admin', module: 'admin' do
+      put 'profiles/:id', to: 'profiles#update', as: :user_profile
+    end
   end
 end

--- a/plugins/ShinyProfiles/db/migrate/20201128224232_create_shiny_profiles_tables.rb
+++ b/plugins/ShinyProfiles/db/migrate/20201128224232_create_shiny_profiles_tables.rb
@@ -1,0 +1,31 @@
+class CreateShinyProfilesTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shiny_profiles_profiles do |t|
+      t.string :public_name
+      t.string :public_email
+      t.text :bio
+      t.string :location
+      t.string :postcode
+
+      t.boolean :show_on_site, null: false, default: true
+      t.boolean :show_in_gallery, null: false, default: true
+      t.boolean :show_to_unauthenticated, null: false, default: true
+
+      t.belongs_to :user, foreign_key: true, null: false
+
+      t.timestamps
+      t.datetime :deleted_at, precision: 6, index: true
+    end
+
+    create_table :shiny_profiles_links do |t|
+      t.string :name, null: false
+      t.string :url, null: false
+      t.integer :position
+
+      t.belongs_to :profile, foreign_key: { to_table: :shiny_profiles_profiles }, null: false
+
+      t.timestamps
+      t.datetime :deleted_at, precision: 6, index: true
+    end
+  end
+end

--- a/plugins/ShinyProfiles/db/seeds.rb
+++ b/plugins/ShinyProfiles/db/seeds.rb
@@ -10,9 +10,9 @@
 # rails shiny_profiles:db:seed
 
 # Add feature flag
-flag = FeatureFlag.find_or_create_by!( name: 'profile_pages' )
+flag = FeatureFlag.find_or_create_by!( name: 'user_profiles' )
 flag.update!(
-  description: 'Enable user profile pages, provided by ShinyProfiles plugin',
+  description: 'User profile pages (provided by ShinyProfiles plugin)',
   enabled: true,
   enabled_for_logged_in: true,
   enabled_for_admins: true

--- a/plugins/ShinyProfiles/spec/factories/shiny_profiles/profiles.rb
+++ b/plugins/ShinyProfiles/spec/factories/shiny_profiles/profiles.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Factory for user profiles
+module ShinyProfiles
+  FactoryBot.define do
+    factory :user_profile, class: 'ShinyProfiles::Profile' do
+      public_name { Faker::Name.unique.name }
+      show_on_site { true }
+      show_in_gallery { true }
+      show_to_unauthenticated { true }
+
+      association :user
+    end
+  end
+end

--- a/plugins/ShinyProfiles/spec/models/shiny_profiles/profile_spec.rb
+++ b/plugins/ShinyProfiles/spec/models/shiny_profiles/profile_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+require 'rails_helper'
+
+# Tests for user profile model
+module ShinyProfiles
+  RSpec.describe Profile, type: :model do
+    context 'Instance methods' do
+      describe '.name' do
+        it 'returns the public_name if one is set' do
+          profile = create :user_profile
+
+          expect( profile.name ).to eq profile.public_name
+        end
+
+        it "returns the user's username if no public_name is set" do
+          profile = create :user_profile, public_name: nil
+
+          expect( profile.name ).to eq profile.user.username
+        end
+      end
+    end
+  end
+end

--- a/plugins/ShinyProfiles/spec/requests/admin/profiles_spec.rb
+++ b/plugins/ShinyProfiles/spec/requests/admin/profiles_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+require 'rails_helper'
+
+# Tests for admin area controller
+RSpec.describe ShinyProfiles::Admin::ProfilesController, type: :request do
+  before :each do
+    admin = create :user_admin
+    sign_in admin
+  end
+
+  describe 'GET /admin/profiles/123/edit' do
+    it "renders the user's edit-profile page" do
+      profile = create :user_profile
+
+      get shiny_profiles.admin_edit_profile_path( profile )
+
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_title I18n.t( 'shiny_profiles.admin.profiles.edit.title' ).titlecase
+    end
+  end
+
+  describe 'PUT /admin/profiles/123' do
+    it 'saves the new profile details' do
+      profile = create :user_profile
+
+      new_email = Faker::Internet.unique.email.sub( '@', ' AT ' )
+
+      put shiny_profiles.admin_profile_path( profile ), params: {
+        profile: {
+          public_email: new_email
+        }
+      }
+
+      expect( response      ).to have_http_status :found
+      expect( response      ).to redirect_to shiny_profiles.admin_edit_profile_path( profile )
+      follow_redirect!
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_field 'profile[public_email]', with: new_email
+    end
+  end
+end

--- a/plugins/ShinyProfiles/spec/requests/profiles_spec.rb
+++ b/plugins/ShinyProfiles/spec/requests/profiles_spec.rb
@@ -39,11 +39,11 @@ RSpec.describe ShinyProfiles::ProfilesController, type: :request do
       expect( response.body ).to have_title profile.name
     end
 
-    it "renders the CMS 404 page if the username doesn't exist" do
-      get shiny_profiles.profile_path( 'syzygy' )
+    it "renders the 404 page if the user doesn't exist" do
+      get shiny_profiles.profile_path( 'no.such.user' )
 
       expect( response      ).to have_http_status :not_found
-      expect( response.body ).to have_css 'h2', text: I18n.t( 'errors.not_found.title', resource_type: 'Profile' )
+      expect( response.body ).to have_title I18n.t( 'errors.not_found.title', resource_type: 'Profile' )
     end
   end
 
@@ -55,6 +55,13 @@ RSpec.describe ShinyProfiles::ProfilesController, type: :request do
 
       expect( response      ).to have_http_status :ok
       expect( response.body ).to have_title profile.name
+    end
+
+    it "renders the 404 page if the user doesn't exist" do
+      get shiny_profiles.edit_profile_path( 'no.such.user' )
+
+      expect( response      ).to have_http_status :not_found
+      expect( response.body ).to have_title I18n.t( 'errors.not_found.title', resource_type: 'Profile' )
     end
   end
 

--- a/plugins/ShinyProfiles/spec/requests/profiles_spec.rb
+++ b/plugins/ShinyProfiles/spec/requests/profiles_spec.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
+# ShinyProfiles plugin for ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
 require 'rails_helper'
 
-RSpec.describe 'User profiles', type: :request do
+# Tests for main site controller
+RSpec.describe ShinyProfiles::ProfilesController, type: :request do
   before :each do
     FeatureFlag.enable :user_login
-    FeatureFlag.enable :profile_pages
+    FeatureFlag.enable :user_profiles
   end
 
   describe 'GET /profiles' do
@@ -24,12 +31,12 @@ RSpec.describe 'User profiles', type: :request do
 
   describe 'GET /profile/:username' do
     it "renders the user's profile page" do
-      user = create :user
+      profile = create :user_profile
 
-      get shiny_profiles.profile_path( user.username )
+      get shiny_profiles.profile_path( profile.username )
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to include user.username
+      expect( response.body ).to have_title profile.name
     end
 
     it "renders the CMS 404 page if the username doesn't exist" do
@@ -52,46 +59,51 @@ RSpec.describe 'User profiles', type: :request do
     end
 
     it "redirects to the user's profile page when user is already logged in" do
-      user = create :user
-      sign_in user
+      profile = create :user_profile
+      sign_in profile.user
 
       get shiny_profiles.profile_redirect_path
 
       expect( response      ).to have_http_status :found
-      expect( response      ).to redirect_to shiny_profiles.profile_path( user.username )
+      expect( response      ).to redirect_to shiny_profiles.profile_path( profile.username )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to include user.username
+      expect( response.body ).to have_title profile.name
     end
   end
 
   describe 'POST /login' do
     it "redirects to the user's profile page if user profiles are enabled" do
-      password = 'shinycms unimaginative test passphrase'
+      password = Faker::Books::CultureSeries.book
       user = create :user, password: password
+      create :user_profile, user: user
 
       post user_session_path, params: {
-        'user[login]': user.username,
-        'user[password]': password
+        user: {
+          login: user.username,
+          password: password
+        }
       }
 
       expect( response      ).to have_http_status :found
       expect( response      ).to redirect_to shiny_profiles.profile_path( user.username )
       follow_redirect!
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to have_css 'h2', text: user.name
+      expect( response.body ).to have_title user.profile.name
     end
 
     it "redirects to the site root if user profiles aren't enabled" do
-      password = 'shinycms unimaginative test passphrase'
+      password = Faker::Books::CultureSeries.book
       user = create :user, password: password
 
-      FeatureFlag.disable :profile_pages
+      FeatureFlag.disable :user_profiles
       page = create :top_level_page
 
       post user_session_path, params: {
-        'user[login]': user.username,
-        'user[password]': password
+        user: {
+          login: user.username,
+          password: password
+        }
       }
 
       expect( response      ).to have_http_status :found

--- a/plugins/ShinyProfiles/spec/requests/profiles_spec.rb
+++ b/plugins/ShinyProfiles/spec/requests/profiles_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe ShinyProfiles::ProfilesController, type: :request do
     end
   end
 
+  describe 'GET /profile/:username/edit' do
+    it "renders the user's edit-profile page" do
+      profile = create :user_profile
+
+      get shiny_profiles.edit_profile_path( profile.username )
+
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_title profile.name
+    end
+  end
+
   describe 'GET /profile' do
     it 'redirects to the login page if a user is not currently logged in' do
       get shiny_profiles.profile_redirect_path

--- a/plugins/ShinySearch/spec/requests/search_spec.rb
+++ b/plugins/ShinySearch/spec/requests/search_spec.rb
@@ -3,8 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Search:', type: :request do
+  before :all do
+    FeatureFlag.enable :user_profiles
+  end
+
   before :each do
-    @user = create :user, public_name: 'Success'
+    @profile = create :user_profile, public_name: 'Success'
   end
 
   describe 'GET /search' do
@@ -22,7 +26,7 @@ RSpec.describe 'Search:', type: :request do
 
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'shiny_search.search.results.title', query: 'Success' )
-      expect( response.body ).to     have_link @user.name, href: shiny_profiles.profile_path( @user.username )
+      expect( response.body ).to     have_link @profile.name, href: shiny_profiles.profile_path( @profile.username )
       expect( response.body ).not_to have_css 'p', text: I18n.t( 'shiny_search.search.no_results.no_results' )
     end
 
@@ -48,7 +52,7 @@ RSpec.describe 'Search:', type: :request do
 
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'shiny_search.search.results.title', query: 'Success' )
-      expect( response.body ).to     have_link @user.name, href: shiny_profiles.profile_path( @user.username )
+      expect( response.body ).to     have_link @profile.name, href: shiny_profiles.profile_path( @profile.username )
       expect( response.body ).not_to have_css 'p', text: I18n.t( 'shiny_search.search.no_results.no_results' )
     end
   end
@@ -60,7 +64,7 @@ RSpec.describe 'Search:', type: :request do
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'shiny_search.search.results.title', query: 'Success' )
       # TODO
-      # expect( response.body ).to     have_link @user.name, href: shiny_profiles.profile_path( @user.username )
+      # expect( response.body ).to     have_link @profile.name, href: shiny_profiles.profile_path( @profile.username )
       # expect( response.body ).not_to have_css 'p', text: I18n.t( 'shiny_search.search.no_results.no_results' )
     end
   end
@@ -72,7 +76,7 @@ RSpec.describe 'Search:', type: :request do
       expect( response      ).to     have_http_status :ok
       expect( response.body ).to     have_title I18n.t( 'shiny_search.search.results.title', query: 'FAIL' )
       expect( response.body ).to     have_css 'p', text: I18n.t( 'shiny_search.search.no_results.no_results' )
-      expect( response.body ).not_to have_link @user.name, href: shiny_profiles.profile_path( @user.username )
+      expect( response.body ).not_to have_link @profile.name, href: shiny_profiles.profile_path( @profile.username )
     end
   end
 end

--- a/spec/requests/feature_flags_spec.rb
+++ b/spec/requests/feature_flags_spec.rb
@@ -12,7 +12,7 @@ require 'rails_helper'
 RSpec.describe 'Feature Flags', type: :request do
   before :each do
     FeatureFlag.enable :user_login
-    FeatureFlag.enable :profile_pages
+    FeatureFlag.enable :user_profiles
   end
 
   describe 'GET /login' do
@@ -51,7 +51,7 @@ RSpec.describe 'Feature Flags', type: :request do
       user = create :user
       sign_in user
 
-      FeatureFlag.find_or_create_by!( name: 'profile_pages' )
+      FeatureFlag.find_or_create_by!( name: 'user_profiles' )
                  .update!( enabled: false, enabled_for_logged_in: false, enabled_for_admins: true )
 
       get shiny_profiles.profile_path( user.username )
@@ -64,22 +64,23 @@ RSpec.describe 'Feature Flags', type: :request do
         '.alerts',
         text: I18n.t(
           'feature_flags.off_alert',
-          feature_name: I18n.t( 'feature_flags.profile_pages' )
+          feature_name: I18n.t( 'feature_flags.user_profiles' )
         )
       )
     end
 
     it 'succeeds for admin user with Profile Pages feature only enabled for admins' do
       user = create :admin_user
+      create :user_profile, user: user
       sign_in user
 
-      FeatureFlag.find_or_create_by!( name: 'profile_pages' )
+      FeatureFlag.find_or_create_by!( name: 'user_profiles' )
                  .update!( enabled: false, enabled_for_logged_in: false, enabled_for_admins: true )
 
       get shiny_profiles.profile_path( user.username )
 
       expect( response      ).to have_http_status :ok
-      expect( response.body ).to include user.username
+      expect( response.body ).to have_title user.profile.name
     end
   end
 end

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'User Accounts', type: :request do
 
   before :each do
     FeatureFlag.enable :user_login
-    FeatureFlag.disable :profile_pages
+    FeatureFlag.disable :user_profiles
   end
 
   describe 'GET /account/register' do


### PR DESCRIPTION
Probably still a few odds and ends to tidy up, but this PR gets the vast majority of the user profile functionality separated out into the ShinyProfiles plugin.

It feels like there are a few places where the boundary-crossing is non-ideal (between User and Profile model methods, particularly), so more thinking required there at some point.