### PR TITLE
Drop microseconds from timestamps

### DIFF
--- a/config/initializers/activerecord_timestamp_precision.rb
+++ b/config/initializers/activerecord_timestamp_precision.rb
@@ -10,7 +10,8 @@ require 'active_record/connection_adapters/postgresql_adapter'
 
 module ActiveRecord
   module ConnectionAdapters
-    # Override default Rails 6 behavior, so we get timestamps without milliseconds
+    # Override default Rails 6 behavior; microsecond timestamps seem a bit excessive
+    # for a CMS, and they add clutter and noise if/when you want to look at the data
     class PostgreSQLAdapter
       def supports_datetime_with_precision?
         # :nocov:

--- a/config/initializers/activerecord_timestamp_precision.rb
+++ b/config/initializers/activerecord_timestamp_precision.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2020 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    # Override default Rails 6 behavior, so we get timestamps without milliseconds
+    class PostgreSQLAdapter
+      def supports_datetime_with_precision?
+        # :nocov:
+        false
+        # :nocov:
+      end
+    end
+  end
+end

--- a/db/archived-migrations/20200915212009_create_shiny_blog_posts.shiny_blog.rb
+++ b/db/archived-migrations/20200915212009_create_shiny_blog_posts.shiny_blog.rb
@@ -17,7 +17,7 @@ class CreateShinyBlogPosts < ActiveRecord::Migration[6.0]
 
       t.belongs_to :user, foreign_key: true, null: false
 
-      t.timestamp :posted_at, precision: 6, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamp :posted_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
       t.timestamps
     end
   end

--- a/db/archived-migrations/20200915212037_create_shiny_news_posts.shiny_news.rb
+++ b/db/archived-migrations/20200915212037_create_shiny_news_posts.shiny_news.rb
@@ -17,7 +17,7 @@ class CreateShinyNewsPosts < ActiveRecord::Migration[6.0]
 
       t.belongs_to :user, foreign_key: true, null: false
 
-      t.timestamp :posted_at, precision: 6, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamp :posted_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
       t.timestamps
     end
   end

--- a/db/archived-migrations/20200915220751_add_shiny_lists_tables.shiny_lists.rb
+++ b/db/archived-migrations/20200915220751_add_shiny_lists_tables.shiny_lists.rb
@@ -24,8 +24,8 @@ class AddShinyListsTables < ActiveRecord::Migration[6.0]
 
       t.references :consent_version, foreign_key: true, null: false
 
-      t.timestamp :subscribed_at, precision: 6, null: false, default: -> { 'CURRENT_TIMESTAMP' }
-      t.timestamp :unsubscribed_at, precision: 6
+      t.timestamp :subscribed_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamp :unsubscribed_at
       t.timestamps
     end
   end

--- a/db/archived-migrations/20200915225123_create_shiny_newsletters_tables.shiny_newsletters.rb
+++ b/db/archived-migrations/20200915225123_create_shiny_newsletters_tables.shiny_newsletters.rb
@@ -42,7 +42,7 @@ class CreateShinyNewslettersTables < ActiveRecord::Migration[6.0]
 
       t.references :template, references: :shiny_newsletters_templates, foreign_key: { to_table: :shiny_newsletters_templates }, null: false
 
-      t.timestamp :published_at, precision: 6
+      t.timestamp :published_at
       t.timestamps
     end
 
@@ -61,9 +61,9 @@ class CreateShinyNewslettersTables < ActiveRecord::Migration[6.0]
       t.references :edition, references: :shiny_newsletters_editions, foreign_key: { to_table: :shiny_newsletters_editions }, null: false
       t.references :list, references: :shiny_lists_lists, foreign_key: { to_table: :shiny_lists_lists }, null: false
 
-      t.timestamp :send_at, precision: 6
-      t.timestamp :started_sending_at, precision: 6
-      t.timestamp :finished_sending_at, precision: 6
+      t.timestamp :send_at
+      t.timestamp :started_sending_at
+      t.timestamp :finished_sending_at
       t.timestamps
     end
   end

--- a/db/archived-migrations/20201001180612_add_confirm_to_email_recipient.rb
+++ b/db/archived-migrations/20201001180612_add_confirm_to_email_recipient.rb
@@ -9,7 +9,7 @@
 class AddConfirmToEmailRecipient < ActiveRecord::Migration[6.0]
   def change
     add_column :email_recipients, :confirm_token, :uuid
-    add_column :email_recipients, :confirm_sent_at, :timestamp, precision: 6
-    add_column :email_recipients, :confirmed_at, :timestamp, precision: 6
+    add_column :email_recipients, :confirm_sent_at, :timestamp
+    add_column :email_recipients, :confirmed_at, :timestamp
   end
 end

--- a/db/migrate/20201007212946_add_deleted_at_to_user.rb
+++ b/db/migrate/20201007212946_add_deleted_at_to_user.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToUser < ActiveRecord::Migration[6.0]
   def change
-    add_column :users, :deleted_at, :timestamp, precision: 6
+    add_column :users, :deleted_at, :timestamp
     add_index :users, :deleted_at
   end
 end

--- a/db/migrate/20201008220616_add_deleted_at_to_blog_post.shiny_blog.rb
+++ b/db/migrate/20201008220616_add_deleted_at_to_blog_post.shiny_blog.rb
@@ -1,7 +1,7 @@
 # This migration comes from shiny_blog (originally 20201008220226)
 class AddDeletedAtToBlogPost < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_blog_posts, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_blog_posts, :deleted_at, :timestamp
     add_index :shiny_blog_posts, :deleted_at
   end
 end

--- a/db/migrate/20201008220622_add_deleted_at_to_news_post.shiny_news.rb
+++ b/db/migrate/20201008220622_add_deleted_at_to_news_post.shiny_news.rb
@@ -1,7 +1,7 @@
 # This migration comes from shiny_news (originally 20201008220226)
 class AddDeletedAtToNewsPost < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_news_posts, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_news_posts, :deleted_at, :timestamp
     add_index :shiny_news_posts, :deleted_at
   end
 end

--- a/db/migrate/20201008233537_add_deleted_at_to_discussion.rb
+++ b/db/migrate/20201008233537_add_deleted_at_to_discussion.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToDiscussion < ActiveRecord::Migration[6.0]
   def change
-    add_column :discussions, :deleted_at, :timestamp, precision: 6
+    add_column :discussions, :deleted_at, :timestamp
     add_index :discussions, :deleted_at
   end
 end

--- a/db/migrate/20201008233543_add_deleted_at_to_comment.rb
+++ b/db/migrate/20201008233543_add_deleted_at_to_comment.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToComment < ActiveRecord::Migration[6.0]
   def change
-    add_column :comments, :deleted_at, :timestamp, precision: 6
+    add_column :comments, :deleted_at, :timestamp
     add_index :comments, :deleted_at
   end
 end

--- a/db/migrate/20201008234150_add_deleted_at_to_comment_author.rb
+++ b/db/migrate/20201008234150_add_deleted_at_to_comment_author.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToCommentAuthor < ActiveRecord::Migration[6.0]
   def change
-    add_column :comment_authors, :deleted_at, :timestamp, precision: 6
+    add_column :comment_authors, :deleted_at, :timestamp
     add_index :comment_authors, :deleted_at
   end
 end

--- a/db/migrate/20201008234156_add_deleted_at_to_consent_version.rb
+++ b/db/migrate/20201008234156_add_deleted_at_to_consent_version.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToConsentVersion < ActiveRecord::Migration[6.0]
   def change
-    add_column :consent_versions, :deleted_at, :timestamp, precision: 6
+    add_column :consent_versions, :deleted_at, :timestamp
     add_index :consent_versions, :deleted_at
   end
 end

--- a/db/migrate/20201008234205_add_deleted_at_to_do_not_contact.rb
+++ b/db/migrate/20201008234205_add_deleted_at_to_do_not_contact.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToDoNotContact < ActiveRecord::Migration[6.0]
   def change
-    add_column :do_not_contacts, :deleted_at, :timestamp, precision: 6
+    add_column :do_not_contacts, :deleted_at, :timestamp
     add_index :do_not_contacts, :deleted_at
   end
 end

--- a/db/migrate/20201008234213_add_deleted_at_to_feature_flag.rb
+++ b/db/migrate/20201008234213_add_deleted_at_to_feature_flag.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToFeatureFlag < ActiveRecord::Migration[6.0]
   def change
-    add_column :feature_flags, :deleted_at, :timestamp, precision: 6
+    add_column :feature_flags, :deleted_at, :timestamp
     add_index :feature_flags, :deleted_at
   end
 end

--- a/db/migrate/20201008235031_add_deleted_at_to_email_recipient.rb
+++ b/db/migrate/20201008235031_add_deleted_at_to_email_recipient.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToEmailRecipient < ActiveRecord::Migration[6.0]
   def change
-    add_column :email_recipients, :deleted_at, :timestamp, precision: 6
+    add_column :email_recipients, :deleted_at, :timestamp
     add_index :email_recipients, :deleted_at
   end
 end

--- a/db/migrate/20201009125021_add_deleted_at_to_forms.shiny_forms.rb
+++ b/db/migrate/20201009125021_add_deleted_at_to_forms.shiny_forms.rb
@@ -1,7 +1,7 @@
 # This migration comes from shiny_forms (originally 20201009124440)
 class AddDeletedAtToForms < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_forms_forms, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_forms_forms, :deleted_at, :timestamp
     add_index :shiny_forms_forms, :deleted_at
   end
 end

--- a/db/migrate/20201009125026_add_deleted_at_to_lists_and_subscriptions.shiny_lists.rb
+++ b/db/migrate/20201009125026_add_deleted_at_to_lists_and_subscriptions.shiny_lists.rb
@@ -1,8 +1,8 @@
 # This migration comes from shiny_lists (originally 20201009124505)
 class AddDeletedAtToListsAndSubscriptions < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_lists_lists, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_lists_subscriptions, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_lists_lists, :deleted_at, :timestamp
+    add_column :shiny_lists_subscriptions, :deleted_at, :timestamp
     add_index :shiny_lists_lists, :deleted_at
     add_index :shiny_lists_subscriptions, :deleted_at
   end

--- a/db/migrate/20201009125033_add_deleted_at_to_insert_sets_and_elements.shiny_inserts.rb
+++ b/db/migrate/20201009125033_add_deleted_at_to_insert_sets_and_elements.shiny_inserts.rb
@@ -1,8 +1,8 @@
 # This migration comes from shiny_inserts (originally 20201009124530)
 class AddDeletedAtToInsertSetsAndElements < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_inserts_sets, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_inserts_elements, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_inserts_sets, :deleted_at, :timestamp
+    add_column :shiny_inserts_elements, :deleted_at, :timestamp
     add_index :shiny_inserts_sets, :deleted_at
     add_index :shiny_inserts_elements, :deleted_at
   end

--- a/db/migrate/20201009144825_add_deleted_at_to_capabilities.rb
+++ b/db/migrate/20201009144825_add_deleted_at_to_capabilities.rb
@@ -1,7 +1,7 @@
 class AddDeletedAtToCapabilities < ActiveRecord::Migration[6.0]
   def change
-    add_column :capability_categories, :deleted_at, :timestamp, precision: 6
-    add_column :capabilities, :deleted_at, :timestamp, precision: 6
+    add_column :capability_categories, :deleted_at, :timestamp
+    add_column :capabilities, :deleted_at, :timestamp
     add_index :capability_categories, :deleted_at
     add_index :capabilities, :deleted_at
   end

--- a/db/migrate/20201009144833_add_deleted_at_to_settings.rb
+++ b/db/migrate/20201009144833_add_deleted_at_to_settings.rb
@@ -1,7 +1,7 @@
 class AddDeletedAtToSettings < ActiveRecord::Migration[6.0]
   def change
-    add_column :settings, :deleted_at, :timestamp, precision: 6
-    add_column :setting_values, :deleted_at, :timestamp, precision: 6
+    add_column :settings, :deleted_at, :timestamp
+    add_column :setting_values, :deleted_at, :timestamp
     add_index :settings, :deleted_at
     add_index :setting_values, :deleted_at
   end

--- a/db/migrate/20201009163432_add_deleted_at_to_page_tables.shiny_pages.rb
+++ b/db/migrate/20201009163432_add_deleted_at_to_page_tables.shiny_pages.rb
@@ -1,11 +1,11 @@
 # This migration comes from shiny_pages (originally 20201009162910)
 class AddDeletedAtToPageTables < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_pages_pages, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_pages_page_elements, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_pages_sections, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_pages_templates, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_pages_template_elements, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_pages_pages, :deleted_at, :timestamp
+    add_column :shiny_pages_page_elements, :deleted_at, :timestamp
+    add_column :shiny_pages_sections, :deleted_at, :timestamp
+    add_column :shiny_pages_templates, :deleted_at, :timestamp
+    add_column :shiny_pages_template_elements, :deleted_at, :timestamp
     add_index :shiny_pages_pages, :deleted_at
     add_index :shiny_pages_page_elements, :deleted_at
     add_index :shiny_pages_sections, :deleted_at

--- a/db/migrate/20201009163441_add_deleted_at_to_newsletter_tables.shiny_newsletters.rb
+++ b/db/migrate/20201009163441_add_deleted_at_to_newsletter_tables.shiny_newsletters.rb
@@ -1,11 +1,11 @@
 # This migration comes from shiny_newsletters (originally 20201009162923)
 class AddDeletedAtToNewsletterTables < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_newsletters_editions, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_newsletters_edition_elements, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_newsletters_sends, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_newsletters_templates, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_newsletters_template_elements, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_newsletters_editions, :deleted_at, :timestamp
+    add_column :shiny_newsletters_edition_elements, :deleted_at, :timestamp
+    add_column :shiny_newsletters_sends, :deleted_at, :timestamp
+    add_column :shiny_newsletters_templates, :deleted_at, :timestamp
+    add_column :shiny_newsletters_template_elements, :deleted_at, :timestamp
     add_index :shiny_newsletters_editions, :deleted_at
     add_index :shiny_newsletters_edition_elements, :deleted_at
     add_index :shiny_newsletters_sends, :deleted_at

--- a/db/migrate/20201009164412_add_deleted_at_to_user_capabilities.rb
+++ b/db/migrate/20201009164412_add_deleted_at_to_user_capabilities.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToUserCapabilities < ActiveRecord::Migration[6.0]
   def change
-    add_column :user_capabilities, :deleted_at, :timestamp, precision: 6
+    add_column :user_capabilities, :deleted_at, :timestamp
     add_index :user_capabilities, :deleted_at
   end
 end

--- a/db/migrate/20201111195416_create_shiny_access_tables.shiny_access.rb
+++ b/db/migrate/20201111195416_create_shiny_access_tables.shiny_access.rb
@@ -8,20 +8,20 @@ class CreateShinyAccessTables < ActiveRecord::Migration[6.0]
       t.text :description
 
       t.timestamps
-      t.timestamp :deleted_at, precision: 6
+      t.timestamp :deleted_at
     end
 
     create_table :shiny_access_memberships do |t|
       t.references :group, references: :shiny_access_groups, foreign_key: { to_table: :shiny_access_groups }, null: false
       t.references :user, foreign_key: true, null: false
 
-      t.timestamp :began_at,   precision: 6, null: false, default: -> { 'CURRENT_TIMESTAMP' }
-      t.timestamp :expires_at, precision: 6
-      t.timestamp :ended_at,   precision: 6
+      t.timestamp :began_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamp :expires_at
+      t.timestamp :ended_at
       t.text :notes
 
       t.timestamps
-      t.timestamp :deleted_at, precision: 6
+      t.timestamp :deleted_at
     end
 
     add_index :shiny_access_groups, :deleted_at

--- a/db/migrate/20201130234759_create_shiny_profiles_tables.shiny_profiles.rb
+++ b/db/migrate/20201130234759_create_shiny_profiles_tables.shiny_profiles.rb
@@ -15,7 +15,7 @@ class CreateShinyProfilesTables < ActiveRecord::Migration[6.0]
       t.belongs_to :user, foreign_key: true, null: false
 
       t.timestamps
-      t.datetime :deleted_at, precision: 6, index: true
+      t.datetime :deleted_at, index: true
     end
 
     create_table :shiny_profiles_links do |t|
@@ -26,7 +26,7 @@ class CreateShinyProfilesTables < ActiveRecord::Migration[6.0]
       t.belongs_to :profile, foreign_key: { to_table: :shiny_profiles_profiles }, null: false
 
       t.timestamps
-      t.datetime :deleted_at, precision: 6, index: true
+      t.datetime :deleted_at, index: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -116,8 +116,8 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "check_type"
     t.text "message"
     t.datetime "last_run_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_blazer_checks_on_creator_id"
     t.index ["query_id"], name: "index_blazer_checks_on_query_id"
   end
@@ -126,8 +126,8 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.bigint "dashboard_id"
     t.bigint "query_id"
     t.integer "position"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["dashboard_id"], name: "index_blazer_dashboard_queries_on_dashboard_id"
     t.index ["query_id"], name: "index_blazer_dashboard_queries_on_query_id"
   end
@@ -135,8 +135,8 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
   create_table "blazer_dashboards", force: :cascade do |t|
     t.bigint "creator_id"
     t.text "name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_blazer_dashboards_on_creator_id"
   end
 
@@ -146,8 +146,8 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.text "description"
     t.text "statement"
     t.string "data_source"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["creator_id"], name: "index_blazer_queries_on_creator_id"
   end
 
@@ -155,18 +155,18 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "name", null: false
     t.bigint "category_id"
     t.string "description"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["category_id"], name: "index_capabilities_on_category_id"
     t.index ["deleted_at"], name: "index_capabilities_on_deleted_at"
   end
 
   create_table "capability_categories", force: :cascade do |t|
     t.string "name", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_capability_categories_on_deleted_at"
   end
 
@@ -176,9 +176,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.inet "ip_address", null: false
     t.uuid "token", null: false
     t.bigint "email_recipient_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_comment_authors_on_deleted_at"
     t.index ["email_recipient_id"], name: "index_comment_authors_on_email_recipient_id"
   end
@@ -195,10 +195,10 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.boolean "spam", default: false, null: false
     t.string "author_type"
     t.bigint "author_id"
-    t.datetime "posted_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "posted_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["author_id", "author_type"], name: "index_comments_on_author_id_and_author_type"
     t.index ["deleted_at"], name: "index_comments_on_deleted_at"
     t.index ["number", "discussion_id"], name: "index_comments_on_number_and_discussion_id", unique: true
@@ -210,9 +210,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "slug", null: false
     t.text "display_text", null: false
     t.text "admin_notes"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_consent_versions_on_deleted_at"
   end
 
@@ -221,18 +221,18 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.bigint "resource_id"
     t.boolean "locked", default: false, null: false
     t.boolean "show_on_site", default: true, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_discussions_on_deleted_at"
     t.index ["resource_type", "resource_id"], name: "index_discussions_on_resource_type_and_resource_id"
   end
 
   create_table "do_not_contacts", force: :cascade do |t|
     t.string "email"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_do_not_contacts_on_deleted_at"
     t.index ["email"], name: "index_do_not_contacts_on_email", unique: true
   end
@@ -243,11 +243,11 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "canonical_email", null: false
     t.uuid "token", default: -> { "gen_random_uuid()" }, null: false
     t.uuid "confirm_token"
-    t.datetime "confirm_sent_at", precision: 6
-    t.datetime "confirmed_at", precision: 6
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "confirm_sent_at"
+    t.datetime "confirmed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_email_recipients_on_deleted_at"
     t.index ["email"], name: "index_email_recipients_on_email", unique: true
     t.index ["token"], name: "index_email_recipients_on_token", unique: true
@@ -259,9 +259,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.boolean "enabled", default: false, null: false
     t.boolean "enabled_for_logged_in", default: false, null: false
     t.boolean "enabled_for_admins", default: false, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_feature_flags_on_deleted_at"
     t.index ["name"], name: "index_feature_flags_on_name", unique: true
   end
@@ -270,16 +270,16 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.text "content"
     t.string "searchable_type"
     t.bigint "searchable_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
   end
 
   create_table "sessions", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
@@ -288,9 +288,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.bigint "setting_id", null: false
     t.bigint "user_id"
     t.string "value"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_setting_values_on_deleted_at"
     t.index ["setting_id", "user_id"], name: "index_setting_values_on_setting_id_and_user_id", unique: true
   end
@@ -300,9 +300,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "description"
     t.string "level", default: "site", null: false
     t.boolean "locked", default: true, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_settings_on_deleted_at"
   end
 
@@ -311,9 +311,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "public_name"
     t.string "slug", null: false
     t.text "description"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_access_groups_on_deleted_at"
     t.index ["slug"], name: "index_shiny_access_groups_on_slug"
   end
@@ -321,13 +321,13 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
   create_table "shiny_access_memberships", force: :cascade do |t|
     t.bigint "group_id", null: false
     t.bigint "user_id", null: false
-    t.datetime "began_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "expires_at", precision: 6
-    t.datetime "ended_at", precision: 6
+    t.datetime "began_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "expires_at"
+    t.datetime "ended_at"
     t.text "notes"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["began_at"], name: "index_shiny_access_memberships_on_began_at"
     t.index ["deleted_at"], name: "index_shiny_access_memberships_on_deleted_at"
     t.index ["ended_at"], name: "index_shiny_access_memberships_on_ended_at"
@@ -342,10 +342,10 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.text "body"
     t.boolean "show_on_site", default: true, null: false
     t.bigint "user_id", null: false
-    t.datetime "posted_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "posted_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_blog_posts_on_deleted_at"
     t.index ["user_id"], name: "index_shiny_blog_posts_on_user_id"
   end
@@ -362,9 +362,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.boolean "use_akismet", default: true
     t.string "success_message"
     t.string "redirect_to"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_forms_forms_on_deleted_at"
   end
 
@@ -373,18 +373,18 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "content"
     t.string "element_type", default: "short_text", null: false
     t.bigint "set_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_inserts_elements_on_deleted_at"
     t.index ["name"], name: "index_insert_elements_on_name", unique: true
     t.index ["set_id"], name: "index_shiny_inserts_elements_on_set_id"
   end
 
   create_table "shiny_inserts_sets", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_inserts_sets_on_deleted_at"
   end
 
@@ -393,9 +393,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "public_name"
     t.string "slug", null: false
     t.text "description"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_lists_lists_on_deleted_at"
   end
 
@@ -404,11 +404,11 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "subscriber_type", null: false
     t.bigint "subscriber_id", null: false
     t.bigint "consent_version_id", null: false
-    t.datetime "subscribed_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "unsubscribed_at", precision: 6
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "subscribed_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "unsubscribed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["consent_version_id"], name: "index_shiny_lists_subscriptions_on_consent_version_id"
     t.index ["deleted_at"], name: "index_shiny_lists_subscriptions_on_deleted_at"
     t.index ["list_id"], name: "index_shiny_lists_subscriptions_on_list_id"
@@ -421,10 +421,10 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.text "body"
     t.boolean "show_on_site", default: true, null: false
     t.bigint "user_id", null: false
-    t.datetime "posted_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "posted_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_news_posts_on_deleted_at"
     t.index ["user_id"], name: "index_shiny_news_posts_on_user_id"
   end
@@ -435,9 +435,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "element_type", default: "short_text", null: false
     t.integer "position"
     t.bigint "edition_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_newsletters_edition_elements_on_deleted_at"
     t.index ["edition_id"], name: "index_shiny_newsletters_edition_elements_on_edition_id"
   end
@@ -452,10 +452,10 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "subject"
     t.boolean "show_on_site", default: true, null: false
     t.bigint "template_id", null: false
-    t.datetime "published_at", precision: 6
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_newsletters_editions_on_deleted_at"
     t.index ["template_id"], name: "index_shiny_newsletters_editions_on_template_id"
   end
@@ -463,12 +463,12 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
   create_table "shiny_newsletters_sends", force: :cascade do |t|
     t.bigint "edition_id", null: false
     t.bigint "list_id", null: false
-    t.datetime "send_at", precision: 6
-    t.datetime "started_sending_at", precision: 6
-    t.datetime "finished_sending_at", precision: 6
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "send_at"
+    t.datetime "started_sending_at"
+    t.datetime "finished_sending_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_newsletters_sends_on_deleted_at"
     t.index ["edition_id"], name: "index_shiny_newsletters_sends_on_edition_id"
     t.index ["list_id"], name: "index_shiny_newsletters_sends_on_list_id"
@@ -480,9 +480,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "element_type", default: "short_text", null: false
     t.integer "position"
     t.bigint "template_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_newsletters_template_elements_on_deleted_at"
     t.index ["template_id"], name: "index_shiny_newsletters_template_elements_on_template_id"
   end
@@ -491,9 +491,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "name", null: false
     t.text "description"
     t.string "filename", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_newsletters_templates_on_deleted_at"
   end
 
@@ -503,9 +503,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "element_type", default: "short_text", null: false
     t.integer "position"
     t.bigint "page_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_pages_page_elements_on_deleted_at"
     t.index ["page_id"], name: "index_shiny_pages_page_elements_on_page_id"
   end
@@ -520,9 +520,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.boolean "show_on_site", default: true, null: false
     t.bigint "section_id"
     t.bigint "template_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_pages_pages_on_deleted_at"
     t.index ["section_id", "slug"], name: "index_pages_on_section_id_and_slug", unique: true
     t.index ["section_id"], name: "index_shiny_pages_pages_on_section_id"
@@ -539,9 +539,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.boolean "show_on_site", default: true, null: false
     t.bigint "section_id"
     t.bigint "default_page_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["default_page_id"], name: "index_shiny_pages_sections_on_default_page_id"
     t.index ["deleted_at"], name: "index_shiny_pages_sections_on_deleted_at"
     t.index ["section_id", "slug"], name: "index_page_sections_on_section_id_and_slug", unique: true
@@ -554,9 +554,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "element_type", default: "short_text", null: false
     t.integer "position"
     t.bigint "template_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_pages_template_elements_on_deleted_at"
     t.index ["template_id"], name: "index_shiny_pages_template_elements_on_template_id"
   end
@@ -565,9 +565,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "name", null: false
     t.text "description"
     t.string "filename", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_pages_templates_on_deleted_at"
   end
 
@@ -576,9 +576,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.string "url", null: false
     t.integer "position"
     t.bigint "profile_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_profiles_links_on_deleted_at"
     t.index ["profile_id"], name: "index_shiny_profiles_links_on_profile_id"
   end
@@ -593,9 +593,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.boolean "show_in_gallery", default: true, null: false
     t.boolean "show_to_unauthenticated", default: true, null: false
     t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_shiny_profiles_profiles_on_deleted_at"
     t.index ["user_id"], name: "index_shiny_profiles_profiles_on_user_id"
   end
@@ -630,9 +630,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
   create_table "user_capabilities", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "capability_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_user_capabilities_on_deleted_at"
     t.index ["user_id", "capability_id"], name: "index_user_capabilities_on_user_id_and_capability_id", unique: true
   end
@@ -664,9 +664,9 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "deleted_at", precision: 6
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -677,8 +677,8 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
 
   create_table "votable_ips", force: :cascade do |t|
     t.string "ip_address", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "votes", force: :cascade do |t|
@@ -689,8 +689,8 @@ ActiveRecord::Schema.define(version: 2020_12_06_144100) do
     t.boolean "vote_flag"
     t.string "vote_scope"
     t.integer "vote_weight"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["votable_id", "votable_type", "vote_scope"], name: "index_votes_on_votable_id_and_votable_type_and_vote_scope"
     t.index ["votable_type", "votable_id"], name: "index_votes_on_votable_type_and_votable_id"
     t.index ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope"

--- a/plugins/ShinyAccess/db/migrate/20201111033231_create_shiny_access_tables.rb
+++ b/plugins/ShinyAccess/db/migrate/20201111033231_create_shiny_access_tables.rb
@@ -13,13 +13,13 @@ class CreateShinyAccessTables < ActiveRecord::Migration[6.0]
       t.references :group, references: :shiny_access_groups, foreign_key: { to_table: :shiny_access_groups }, null: false
       t.references :user, foreign_key: true, null: false
 
-      t.timestamp :began_at,   precision: 6, null: false, default: -> { 'CURRENT_TIMESTAMP' }
-      t.timestamp :expires_at, precision: 6
-      t.timestamp :ended_at,   precision: 6
+      t.timestamp :began_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamp :expires_at
+      t.timestamp :ended_at
       t.text :notes
 
       t.timestamps
-      t.timestamp :deleted_at, precision: 6
+      t.timestamp :deleted_at
     end
 
     add_index :shiny_access_groups, :deleted_at

--- a/plugins/ShinyBlog/db/migrate/20200812233918_create_shiny_blog_posts.rb
+++ b/plugins/ShinyBlog/db/migrate/20200812233918_create_shiny_blog_posts.rb
@@ -16,7 +16,7 @@ class CreateShinyBlogPosts < ActiveRecord::Migration[6.0]
 
       t.belongs_to :user, foreign_key: true, null: false
 
-      t.timestamp :posted_at, precision: 6, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamp :posted_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
       t.timestamps
     end
   end

--- a/plugins/ShinyBlog/db/migrate/20201008220226_add_deleted_at_to_blog_post.rb
+++ b/plugins/ShinyBlog/db/migrate/20201008220226_add_deleted_at_to_blog_post.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToBlogPost < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_blog_posts, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_blog_posts, :deleted_at, :timestamp
     add_index :shiny_blog_posts, :deleted_at
   end
 end

--- a/plugins/ShinyForms/db/migrate/20201009124440_add_deleted_at_to_forms.rb
+++ b/plugins/ShinyForms/db/migrate/20201009124440_add_deleted_at_to_forms.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToForms < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_forms_forms, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_forms_forms, :deleted_at, :timestamp
     add_index :shiny_forms_forms, :deleted_at
   end
 end

--- a/plugins/ShinyInserts/db/migrate/20201009124530_add_deleted_at_to_insert_sets_and_elements.rb
+++ b/plugins/ShinyInserts/db/migrate/20201009124530_add_deleted_at_to_insert_sets_and_elements.rb
@@ -1,7 +1,7 @@
 class AddDeletedAtToInsertSetsAndElements < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_inserts_sets, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_inserts_elements, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_inserts_sets, :deleted_at, :timestamp
+    add_column :shiny_inserts_elements, :deleted_at, :timestamp
     add_index :shiny_inserts_sets, :deleted_at
     add_index :shiny_inserts_elements, :deleted_at
   end

--- a/plugins/ShinyLists/db/migrate/20200823014211_add_shiny_lists_tables.rb
+++ b/plugins/ShinyLists/db/migrate/20200823014211_add_shiny_lists_tables.rb
@@ -23,8 +23,8 @@ class AddShinyListsTables < ActiveRecord::Migration[6.0]
 
       t.references :consent_version, foreign_key: true, null: false
 
-      t.timestamp :subscribed_at, precision: 6, null: false, default: -> { 'CURRENT_TIMESTAMP' }
-      t.timestamp :unsubscribed_at, precision: 6
+      t.timestamp :subscribed_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamp :unsubscribed_at
       t.timestamps
     end
   end

--- a/plugins/ShinyLists/db/migrate/20201009124505_add_deleted_at_to_lists_and_subscriptions.rb
+++ b/plugins/ShinyLists/db/migrate/20201009124505_add_deleted_at_to_lists_and_subscriptions.rb
@@ -1,7 +1,7 @@
 class AddDeletedAtToListsAndSubscriptions < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_lists_lists, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_lists_subscriptions, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_lists_lists, :deleted_at, :timestamp
+    add_column :shiny_lists_subscriptions, :deleted_at, :timestamp
     add_index :shiny_lists_lists, :deleted_at
     add_index :shiny_lists_subscriptions, :deleted_at
   end

--- a/plugins/ShinyNews/db/migrate/20200806233918_create_shiny_news_posts.rb
+++ b/plugins/ShinyNews/db/migrate/20200806233918_create_shiny_news_posts.rb
@@ -16,7 +16,7 @@ class CreateShinyNewsPosts < ActiveRecord::Migration[6.0]
 
       t.belongs_to :user, foreign_key: true, null: false
 
-      t.timestamp :posted_at, precision: 6, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.timestamp :posted_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
       t.timestamps
     end
   end

--- a/plugins/ShinyNews/db/migrate/20201008220226_add_deleted_at_to_news_post.rb
+++ b/plugins/ShinyNews/db/migrate/20201008220226_add_deleted_at_to_news_post.rb
@@ -1,6 +1,6 @@
 class AddDeletedAtToNewsPost < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_news_posts, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_news_posts, :deleted_at, :timestamp
     add_index :shiny_news_posts, :deleted_at
   end
 end

--- a/plugins/ShinyNewsletters/db/migrate/20200823235007_create_shiny_newsletters_tables.rb
+++ b/plugins/ShinyNewsletters/db/migrate/20200823235007_create_shiny_newsletters_tables.rb
@@ -41,7 +41,7 @@ class CreateShinyNewslettersTables < ActiveRecord::Migration[6.0]
 
       t.references :template, references: :shiny_newsletters_templates, foreign_key: { to_table: :shiny_newsletters_templates }, null: false
 
-      t.timestamp :published_at, precision: 6
+      t.timestamp :published_at
       t.timestamps
     end
 
@@ -60,9 +60,9 @@ class CreateShinyNewslettersTables < ActiveRecord::Migration[6.0]
       t.references :edition, references: :shiny_newsletters_editions, foreign_key: { to_table: :shiny_newsletters_editions }, null: false
       t.references :list, references: :shiny_lists_lists, foreign_key: { to_table: :shiny_lists_lists }, null: false
 
-      t.timestamp :send_at, precision: 6
-      t.timestamp :started_sending_at, precision: 6
-      t.timestamp :finished_sending_at, precision: 6
+      t.timestamp :send_at
+      t.timestamp :started_sending_at
+      t.timestamp :finished_sending_at
       t.timestamps
     end
   end

--- a/plugins/ShinyNewsletters/db/migrate/20201009162923_add_deleted_at_to_newsletter_tables.rb
+++ b/plugins/ShinyNewsletters/db/migrate/20201009162923_add_deleted_at_to_newsletter_tables.rb
@@ -1,10 +1,10 @@
 class AddDeletedAtToNewsletterTables < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_newsletters_editions, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_newsletters_edition_elements, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_newsletters_sends, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_newsletters_templates, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_newsletters_template_elements, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_newsletters_editions, :deleted_at, :timestamp
+    add_column :shiny_newsletters_edition_elements, :deleted_at, :timestamp
+    add_column :shiny_newsletters_sends, :deleted_at, :timestamp
+    add_column :shiny_newsletters_templates, :deleted_at, :timestamp
+    add_column :shiny_newsletters_template_elements, :deleted_at, :timestamp
     add_index :shiny_newsletters_editions, :deleted_at
     add_index :shiny_newsletters_edition_elements, :deleted_at
     add_index :shiny_newsletters_sends, :deleted_at

--- a/plugins/ShinyPages/db/migrate/20201009162910_add_deleted_at_to_page_tables.rb
+++ b/plugins/ShinyPages/db/migrate/20201009162910_add_deleted_at_to_page_tables.rb
@@ -1,10 +1,10 @@
 class AddDeletedAtToPageTables < ActiveRecord::Migration[6.0]
   def change
-    add_column :shiny_pages_pages, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_pages_page_elements, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_pages_sections, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_pages_templates, :deleted_at, :timestamp, precision: 6
-    add_column :shiny_pages_template_elements, :deleted_at, :timestamp, precision: 6
+    add_column :shiny_pages_pages, :deleted_at, :timestamp
+    add_column :shiny_pages_page_elements, :deleted_at, :timestamp
+    add_column :shiny_pages_sections, :deleted_at, :timestamp
+    add_column :shiny_pages_templates, :deleted_at, :timestamp
+    add_column :shiny_pages_template_elements, :deleted_at, :timestamp
     add_index :shiny_pages_pages, :deleted_at
     add_index :shiny_pages_page_elements, :deleted_at
     add_index :shiny_pages_sections, :deleted_at

--- a/plugins/ShinyProfiles/db/migrate/20201128224232_create_shiny_profiles_tables.rb
+++ b/plugins/ShinyProfiles/db/migrate/20201128224232_create_shiny_profiles_tables.rb
@@ -14,7 +14,7 @@ class CreateShinyProfilesTables < ActiveRecord::Migration[6.0]
       t.belongs_to :user, foreign_key: true, null: false
 
       t.timestamps
-      t.datetime :deleted_at, precision: 6, index: true
+      t.datetime :deleted_at, index: true
     end
 
     create_table :shiny_profiles_links do |t|
@@ -25,7 +25,7 @@ class CreateShinyProfilesTables < ActiveRecord::Migration[6.0]
       t.belongs_to :profile, foreign_key: { to_table: :shiny_profiles_profiles }, null: false
 
       t.timestamps
-      t.datetime :deleted_at, precision: 6, index: true
+      t.datetime :deleted_at, index: true
     end
   end
 end


### PR DESCRIPTION
(going forward; no migration, should be back and forward compatible though)