### PR TITLE
Back to rubygems for acts_as_votable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,7 @@ source 'https://rubygems.org' do
   gem 'acts-as-taggable-on'
 
   # Likes
-  gem 'acts_as_votable', git: 'https://github.com/ryanto/acts_as_votable'
+  gem 'acts_as_votable'
 
   # Pagination
   gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/ryanto/acts_as_votable
-  revision: 585020dd6ca734b41c35d8cef5193097fecd2705
-  specs:
-    acts_as_votable (0.12.1)
-
 PATH
   remote: plugins/ShinyAccess
   specs:
@@ -175,6 +169,7 @@ GEM
     acts_as_paranoid (0.7.0)
       activerecord (>= 5.2, < 7.0)
       activesupport (>= 5.2, < 7.0)
+    acts_as_votable (0.13.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ahoy_email (1.1.0)
@@ -221,6 +216,8 @@ GEM
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     brakeman (4.10.0)
+    bugsnag (6.18.0)
+      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     bundler-audit (0.7.0.1)
       bundler (>= 1.2.0, < 3)
@@ -590,6 +587,7 @@ DEPENDENCIES
   blazer (= 2.3.1)!
   bootsnap (>= 1.4.2)!
   brakeman!
+  bugsnag!
   bundler-audit!
   capybara (>= 2.15)!
   chartkick (~> 3.4.2)!

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -13,7 +13,6 @@
 ### Rails 6.1 issues
 
 * Deprecation warnings from Devise (I think) when user.save fails
-* Installing acts-as-votable from GitHub to fix its deprecation warnings
 * acts-as-taggable-on downgraded from 6.5.0 to 5.0.0 to get it to install
 
 


### PR DESCRIPTION
Their recent release got rid of the deprecation warnings on Rails 6.1