### PR TITLE
Add config for Ruby Critic

### DIFF
--- a/.rubycritic.yml
+++ b/.rubycritic.yml
@@ -4,6 +4,15 @@ paths:
   - app/
   - config/
   - lib/
-  - plugins/
   - themes/
   - tools/
+  - plugins/ShinyAccess/app/
+  - plugins/ShinyBlog/app/
+  - plugins/ShinyForms/app/
+  - plugins/ShinyInserts/app/
+  - plugins/ShinyLists/app/
+  - plugins/ShinyNews/app/
+  - plugins/ShinyNewsletters/app/
+  - plugins/ShinyPages/app/
+  - plugins/ShinyProfiles/app/
+  - plugins/ShinySearch/app/

--- a/.rubycritic.yml
+++ b/.rubycritic.yml
@@ -2,7 +2,6 @@ branch: 'main'
 no_browser: true
 paths:
   - app/
-  - config/
   - lib/
   - themes/
   - tools/

--- a/.rubycritic.yml
+++ b/.rubycritic.yml
@@ -1,0 +1,10 @@
+branch: 'main'
+no_browser: true
+paths:
+  - app/
+  - config/
+  - lib/
+  - plugins/*/app/
+  - plugins/*/config/
+  - themes/
+  - tools/

--- a/.rubycritic.yml
+++ b/.rubycritic.yml
@@ -4,7 +4,7 @@ paths:
   - app/
   - config/
   - lib/
-  - plugins/*/app/
-  - plugins/*/config/
+  - plugins/**/app/
+  - plugins/**/config/
   - themes/
   - tools/

--- a/.rubycritic.yml
+++ b/.rubycritic.yml
@@ -4,7 +4,6 @@ paths:
   - app/
   - config/
   - lib/
-  - plugins/**/app/
-  - plugins/**/config/
+  - plugins/
   - themes/
   - tools/

--- a/Gemfile
+++ b/Gemfile
@@ -164,7 +164,8 @@ source 'https://rubygems.org' do
     gem 'rails_best_practices'
 
     # Ruby Critic generates easy-to-read reports from various static analysis tools
-    gem 'rubycritic', require: false
+    # FIXME: install this manually (gem install rubycritic) until reek is ruby3 compatible
+    # gem 'rubycritic', '~> 4.5.0', require: false
 
     # Utils for working with translation strings
     # gem 'i18n-debug'

--- a/Gemfile
+++ b/Gemfile
@@ -163,6 +163,9 @@ source 'https://rubygems.org' do
     # Best practices
     gem 'rails_best_practices'
 
+    # Ruby Critic generates easy-to-read reports from various static analysis tools
+    gem 'rubycritic', require: false
+
     # Utils for working with translation strings
     # gem 'i18n-debug'
     gem 'i18n-tasks', '~> 0.9.33'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,10 +238,6 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.16)
     blazer (2.3.1)
       activerecord (>= 5)
@@ -280,8 +276,6 @@ GEM
       json
       simplecov
     coderay (1.1.3)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
@@ -292,8 +286,6 @@ GEM
     database_cleaner-active_record (1.8.0)
       activerecord
       database_cleaner (~> 1.8.0)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     device_detector (1.0.5)
     devise (4.7.3)
       bcrypt (~> 3.0)
@@ -313,7 +305,6 @@ GEM
     email_address (0.1.19)
       netaddr (>= 2.0.4, < 3)
       simpleidn
-    equalizer (0.0.11)
     errbase (0.2.0)
     erubi (1.10.0)
     erubis (2.7.0)
@@ -328,12 +319,6 @@ GEM
       colorize (~> 0.7)
       ruby_parser (>= 3.13.0)
     ffi (1.14.2)
-    flay (2.4.0)
-      ruby_parser (~> 3.0)
-      sexp_processor (~> 4.0)
-    flog (4.2.0)
-      ruby_parser (~> 3.1, > 3.1.0)
-      sexp_processor (~> 4.4)
     geocoder (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -357,7 +342,6 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    ice_nine (0.11.2)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -483,10 +467,6 @@ GEM
     recaptcha (5.6.0)
       json
     redis (4.2.5)
-    reek (1.3.6)
-      ruby2ruby (~> 2.0.7)
-      ruby_parser (~> 3.2)
-      sexp_processor
     regexp_parser (1.8.2)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -543,16 +523,8 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
-    ruby2ruby (2.0.8)
-      ruby_parser (~> 3.1)
-      sexp_processor (~> 4.0)
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
-    rubycritic (0.0.14)
-      flay (= 2.4.0)
-      flog (= 4.2.0)
-      reek (= 1.3.6)
-      virtus (~> 1.0)
     safely_block (0.3.0)
       errbase (>= 0.1.1)
     sassc (2.4.0)
@@ -593,7 +565,6 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.0.1)
-    thread_safe (0.3.6)
     tilt (2.0.10)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -604,11 +575,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    virtus (1.0.5)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
-      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
     webmock (3.11.0)
@@ -687,7 +653,6 @@ DEPENDENCIES
   rubocop-performance!
   rubocop-rails!
   rubocop-rspec!
-  rubycritic!
   sassc-rails!
   seed_dump!
   shiny_access!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,10 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.16)
     blazer (2.3.1)
       activerecord (>= 5)
@@ -276,6 +280,8 @@ GEM
       json
       simplecov
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
@@ -286,6 +292,8 @@ GEM
     database_cleaner-active_record (1.8.0)
       activerecord
       database_cleaner (~> 1.8.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     device_detector (1.0.5)
     devise (4.7.3)
       bcrypt (~> 3.0)
@@ -305,6 +313,7 @@ GEM
     email_address (0.1.19)
       netaddr (>= 2.0.4, < 3)
       simpleidn
+    equalizer (0.0.11)
     errbase (0.2.0)
     erubi (1.10.0)
     erubis (2.7.0)
@@ -319,6 +328,12 @@ GEM
       colorize (~> 0.7)
       ruby_parser (>= 3.13.0)
     ffi (1.14.2)
+    flay (2.4.0)
+      ruby_parser (~> 3.0)
+      sexp_processor (~> 4.0)
+    flog (4.2.0)
+      ruby_parser (~> 3.1, > 3.1.0)
+      sexp_processor (~> 4.4)
     geocoder (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -342,6 +357,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    ice_nine (0.11.2)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -467,6 +483,10 @@ GEM
     recaptcha (5.6.0)
       json
     redis (4.2.5)
+    reek (1.3.6)
+      ruby2ruby (~> 2.0.7)
+      ruby_parser (~> 3.2)
+      sexp_processor
     regexp_parser (1.8.2)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -523,8 +543,16 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
+    ruby2ruby (2.0.8)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
+    rubycritic (0.0.14)
+      flay (= 2.4.0)
+      flog (= 4.2.0)
+      reek (= 1.3.6)
+      virtus (~> 1.0)
     safely_block (0.3.0)
       errbase (>= 0.1.1)
     sassc (2.4.0)
@@ -565,6 +593,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.0.1)
+    thread_safe (0.3.6)
     tilt (2.0.10)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -575,6 +604,11 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
     webmock (3.11.0)
@@ -653,6 +687,7 @@ DEPENDENCIES
   rubocop-performance!
   rubocop-rails!
   rubocop-rspec!
+  rubycritic!
   sassc-rails!
   seed_dump!
   shiny_access!

--- a/app/models/concerns/shiny_post.rb
+++ b/app/models/concerns/shiny_post.rb
@@ -48,8 +48,6 @@ module ShinyPost
     delegate :show_on_site, to: :discussion, allow_nil: true, prefix: true
     delegate :locked, to: :discussion, allow_nil: true, prefix: true
 
-    attr_writer :posted_at_time
-
     # Scopes and default sort order
 
     scope :not_future_dated, -> { where( 'posted_at <= ?', Time.zone.now.iso8601 ) }

--- a/app/models/shiny_plugin.rb
+++ b/app/models/shiny_plugin.rb
@@ -8,7 +8,7 @@
 
 # Provides convenience methods for interacting with ShinyCMS plugins
 class ShinyPlugin
-  attr_accessor :name
+  attr_reader :name
 
   def initialize( name )
     return unless ShinyPlugin.all_names.include? name

--- a/app/models/shiny_post_atom_feed.rb
+++ b/app/models/shiny_post_atom_feed.rb
@@ -14,7 +14,7 @@ class ShinyPostAtomFeed
 
   include Rails.application.routes.url_helpers
 
-  attr_accessor :name, :feed
+  attr_reader :name, :feed
 
   def initialize( feed_name )
     return unless %i[ blog news ].include? feed_name
@@ -42,9 +42,10 @@ class ShinyPostAtomFeed
   private
 
   def write_file_to_local_disk( file_path )
-    File.open file_path, 'w' do |f|
-      f.write feed.to_feed( 'atom' )
-      f.write "\n"
+    feed_text = feed.to_feed( 'atom' )
+
+    File.open file_path, 'w' do |feed_file|
+      feed_file.write "#{feed_text}\n"
     end
   end
 
@@ -89,9 +90,9 @@ class ShinyPostAtomFeed
 
   def add_feed_author
     author = feed.class::Author.new
-    name = author.class::Name.new
-    name.content = site_name # TODO
-    author.name = name
+    author_name = author.class::Name.new
+    author_name.content = site_name # TODO
+    author.name = author_name
     feed.authors << author
   end
 

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -4,7 +4,7 @@
 #
 # Copyright 2009-2020 Denny de la Haye ~ https://denny.me
 #
-# ShinyCMS is free software; you can r  'ShinyNews::AdminController#pagy_url_for',
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
 
 # Config file for Rails Best Practices gem
 # https://github.com/flyerhzm/rails_best_practices#readme / https://rails-bestpractices.com

--- a/docs/Developers/Notes/ruby-3.0.0.md
+++ b/docs/Developers/Notes/ruby-3.0.0.md
@@ -2,21 +2,15 @@
 
 ## Ruby 3.0.0 notes
 
-1. Add `rss` gem to Gemfile (no longer in core)
+* Added `rss` gem to Gemfile (no longer in core)
 
-2. `bundle update`
+* Installing `activerecord_session-store` from GitHub, to pick up an unreleased fix
 
-3. Change Gemfile to get `activerecord_session-store` from GitHub (unreleased fix)
-
-4. Change `:confirmed` trait in email recipient factory from Symbol.to_proc to long form
+* Changed `:confirmed` trait in email recipient factory from Symbol.to_proc to long form
     * Fixes error about "missing receiver", whatever that is
 
-5. REP is throwing a load of warnings:
-    * code -g lib/rails_email_preview/main_app_route_delegator.rb:11
+* REP is throwing a load of warnings
+    * Local fix:
+        * code -g lib/rails_email_preview/main_app_route_delegator.rb:11
         * Change `respond_to?` to `respond_to_missing?`
-            * PR? Check how far back `respond_to_missing?` exists first
-
-6. kaminari is not happy :(
-    * Short-term, to get test suite to pass:
-        * Commented out it_behaves_like Pagination at bottom of blog and news request spec
-    * Medium-term: switched to Pagy - https://github.com/ddnexus/pagy
+    * PR? Check how far back `respond_to_missing?` exists first

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -2,6 +2,8 @@
 
 ## TODO
 
+* Check whether the demo data lost the tags at some point
+
 * Tag cloud/list show and count tags on hidden content
 
 * Blazer currently doesn't restrict people without 'edit' capability to view-only


### PR DESCRIPTION
Had to leave the gem itself commented out in the Gemfile for now, as reek's dependencies haven't caught up with Ruby 3.0 yet... but it's all ready to go once that's sorted out, and you can `gem install rubycritic` in the meantime.