### PR TITLE
Add password scoring endpoint, powered by zxcvbn

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ RSpec/AnyInstance:
     - 'plugins/ShinySearch/spec/requests/search_spec.rb'
     - 'spec/requests/admin/comments_controller_spec.rb'
     - 'spec/requests/discussions_spec.rb'
-    - 'spec/requests/user_spec.rb'
+    - 'spec/requests/users/registrations_controller_spec.rb'
 
 # Offense count: 245
 # Configuration parameters: AssignmentOnly.

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,10 @@ source 'https://rubygems.org' do
   gem 'bcrypt', '~> 3.1.16'
   # Check user passwords against known data leaks
   gem 'devise-pwned_password'
+  # Check password complexity
+  # FIXME: installing from GitHub until they release 1.2.x for ruby 3.x
+  # gem 'zxcvbn-ruby', require: 'zxcvbn'
+  gem 'zxcvbn-ruby', require: 'zxcvbn', git: 'https://github.com/envato/zxcvbn-ruby'
   # Authorisation
   gem 'pundit'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: https://github.com/envato/zxcvbn-ruby
+  revision: e6a9c3eca458ae46f90825538deebb5d71c555fc
+  specs:
+    zxcvbn-ruby (1.2.0)
+
+GIT
   remote: https://github.com/rails/activerecord-session_store
   revision: f188efbc49a522123cc8acc805143824176d01c1
   specs:
@@ -669,6 +675,7 @@ DEPENDENCIES
   sidekiq-status!
   webmock!
   webpacker (~> 5.2)!
+  zxcvbn-ruby!
 
 BUNDLED WITH
    2.2.3

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2021 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Controller for non-Devise, non-admin, password-related features
+class Users::PasswordsController < MainController
+  def test
+    render json: Zxcvbn.test( params[ :password ] )
+  end
+end

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -2,6 +2,11 @@
 
 ## TODO
 
+* Pull admin search methods from controllers to models
+    * Handle user account/profile split
+
+* Check whether creating a user account creates a user profile
+
 * "Mjml: warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."
     * Newsletter plugin tests tend to top the 'slowest tests' list - related?
 

--- a/spec/requests/users/passwords_controller_spec.rb
+++ b/spec/requests/users/passwords_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2021 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+require 'rails_helper'
+
+# Tests for password-related features on main site
+RSpec.describe Users::PasswordsController, type: :request do
+  describe 'GET /account/password/test/Hunter2' do
+    it 'returns a JSON assessment (score and suggestions) for the proposed password' do
+      get test_password_path( 'Hunter2' )
+
+      expect( response ).to have_http_status :ok
+
+      result = JSON.parse( response.body )
+
+      expect( result['score'] ).to eq 0
+      expect( result['crack_time_display'] ).to eq 'instant'
+      expect( result['feedback']['suggestions'] ).to include 'Add another word or two. Uncommon words are better.'
+    end
+  end
+end

--- a/spec/requests/users/sessions_controller_spec.rb
+++ b/spec/requests/users/sessions_controller_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2021 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+require 'rails_helper'
+
+# Tests for user authentication (login/logout) features on main site (powered by Devise)
+RSpec.describe Users::SessionsController, type: :request do
+  before do
+    FeatureFlag.enable :user_login
+    FeatureFlag.disable :user_profiles
+
+    @page = create :top_level_page
+  end
+
+  describe 'GET /login' do
+    it 'renders the user login page if user logins are enabled' do
+      get new_user_session_path
+
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_button I18n.t( 'user.log_in' )
+    end
+
+    it 'redirects to the site homepage if user logins are not enabled' do
+      FeatureFlag.disable :user_login
+
+      get new_user_session_path
+
+      expect( response      ).to have_http_status :found
+      expect( response      ).to redirect_to root_path
+      follow_redirect!
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_css(
+        '.alerts',
+        text: I18n.t(
+          'feature_flags.off_alert',
+          feature_name: I18n.t( 'feature_flags.user_login' )
+        )
+      )
+      expect( response.body ).not_to have_button I18n.t( 'user.log_in' )
+    end
+
+    it 'defaults to assuming that user logins are not enabled' do
+      FeatureFlag.find_by( name: 'user_login' ).update!( name: 'test' )
+
+      get new_user_session_path
+
+      expect( response      ).to have_http_status :found
+      expect( response      ).to redirect_to root_path
+      follow_redirect!
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_css(
+        '.alerts',
+        text: I18n.t(
+          'feature_flags.off_alert',
+          feature_name: I18n.t( 'feature_flags.user_login' )
+        )
+      )
+      expect( response.body ).not_to have_button I18n.t( 'user.log_in' )
+
+      FeatureFlag.find_by( name: 'test' ).update!( name: 'user_login' )
+    end
+  end
+
+  describe 'POST /login' do
+    it 'logs the user in using their email address' do
+      password = 'shinycms unimaginative test passphrase'
+      user = create :user, password: password
+
+      post user_session_path, params: {
+        user: {
+          login:    user.email,
+          password: password
+        }
+      }
+
+      expect( response      ).to have_http_status :found
+      expect( response      ).to redirect_to root_path
+      follow_redirect!
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_link I18n.t( 'user.log_out' )
+    end
+
+    it 'logs the user in using their username' do
+      password = 'shinycms unimaginative test passphrase'
+      user = create :user, password: password
+
+      post user_session_path, params: {
+        user: {
+          login:    user.username,
+          password: password
+        }
+      }
+
+      expect( response      ).to have_http_status :found
+      expect( response      ).to redirect_to root_path
+      follow_redirect!
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_link I18n.t( 'user.log_out' )
+    end
+
+    it 'redirects back to the referring page after login, if it knows it' do
+      password = 'shinycms unimaginative test passphrase'
+      user = create :user, password: password
+
+      different_page = create :top_level_page
+      should_go_here = "http://www.example.com/#{different_page.slug}"
+
+      post user_session_path,
+           params:  {
+             user: {
+               login:    user.username,
+               password: password
+             }
+           },
+           headers: {
+             'HTTP_REFERER': should_go_here
+           }
+
+      expect( response      ).to have_http_status :found
+      expect( response      ).to redirect_to should_go_here
+      follow_redirect!
+      expect( response      ).to have_http_status :ok
+      expect( response.body ).to have_css 'h1', text: different_page.name
+    end
+  end
+end


### PR DESCRIPTION
This PR just creates (and tests) the endpoint; it's not being used in the registration/etc flows yet.

Also refactored the existing user controller tests a little (split up registration and session tests).