### PR TITLE
Add explicit Ruby version to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,7 @@ source 'https://rubygems.org' do
   gem 'pg', '~> 1.2.3'
 
   # Webserver
-  gem 'puma', '~> 5.1'
-
-  # Load ENV from .env(.*) files
-  gem 'dotenv-rails'
+  gem 'puma', '~> 5.1', groups: %i[ development production ]
 
   # Locales for the 'not USA' bits of the world
   gem 'rails-i18n'
@@ -115,8 +112,10 @@ source 'https://rubygems.org' do
   # Better-looking console output
   gem 'amazing_print'
 
-  # Pry is a debugging tool - uncomment it here if you want to use it on the Rails console in production
-  gem 'pry-rails'
+  # Pry is a debugging tool for the Rails console
+  # Uncomment the first line if you want to use it in production, the second otherwise
+  gem 'pry-rails', groups: %i[ development test production ]
+  # gem 'pry-rails', groups: %i[ development test ]
 
   group :production do
     # Bugsnag is an error monitoring service
@@ -127,8 +126,8 @@ source 'https://rubygems.org' do
   end
 
   group :development, :test do
-    # You can enable Pry here if you commented it out in production.
-    # gem 'pry-rails'
+    # Load ENV from .env(.*) files
+    gem 'dotenv-rails'
 
     # Tests are good, m'kay?
     gem 'rspec-rails'
@@ -137,13 +136,6 @@ source 'https://rubygems.org' do
     gem 'factory_bot_rails'
     # Fill test objects with fake data
     gem 'faker'
-
-    # Best practices
-    gem 'rails_best_practices'
-
-    # Ruby Critic generates easy-to-read reports from various static analysis tools
-    # FIXME: install this manually (gem install rubycritic) until reek is ruby3 compatible
-    # gem 'rubycritic', '~> 4.5.0', require: false
 
     # Utils for working with translation strings
     # gem 'i18n-debug'
@@ -167,6 +159,13 @@ source 'https://rubygems.org' do
     # Check for slow code
     gem 'fasterer', require: false
 
+    # Best practices
+    gem 'rails_best_practices'
+
+    # Ruby Critic generates easy-to-read reports from various static analysis tools
+    # FIXME: install this manually (gem install rubycritic) until reek is ruby3 compatible
+    # gem 'rubycritic', '~> 4.5.0', require: false
+
     # Capture all emails sent by the system, and view them in a dev webmail inbox
     gem 'letter_opener_web', '~> 1.0'
 
@@ -184,17 +183,18 @@ source 'https://rubygems.org' do
   end
 
   group :test do
-    # Integration tests (request specs)
-    gem 'capybara', '>= 2.15'
     # Wipe the test database before each test run
     gem 'database_cleaner-active_record'
+
+    # Integration tests (request specs)
+    gem 'capybara', '>= 2.15'
+
+    # Intercept calls to external services (notably, the Algolia API)
+    gem 'webmock'
 
     # Analyse and report on test coverage via CodeCov
     gem 'codecov', require: false
     # Rspec report formatter for Codecov
     gem 'rspec_junit_formatter'
-
-    # Used to intercept calls to the Algolia API
-    gem 'webmock'
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@
 require_relative 'lib/gemfile_plugins_helper'
 
 source 'https://rubygems.org' do
+  # Ruby 3.0
+  ruby '~> 3.0.0'
+
   # Rails 6.1
   gem 'rails', '~> 6.1.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ source 'https://rubygems.org' do
   # Webserver
   gem 'puma', '~> 5.1', groups: %i[ development production ]
 
+  # Load ENV from .env(.*) files
+  gem 'dotenv-rails'
+
   # Locales for the 'not USA' bits of the world
   gem 'rails-i18n'
 
@@ -126,9 +129,6 @@ source 'https://rubygems.org' do
   end
 
   group :development, :test do
-    # Load ENV from .env(.*) files
-    gem 'dotenv-rails'
-
     # Tests are good, m'kay?
     gem 'rspec-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -670,5 +670,8 @@ DEPENDENCIES
   webmock!
   webpacker (~> 5.2)!
 
+RUBY VERSION
+   ruby 3.0.0p0
+
 BUNDLED WITH
    2.2.3

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -2,24 +2,22 @@
 
 ## TODO
 
-* "Mjml: warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."
-    * Newsletter plugin tests tend to top the 'slowest tests' list - related?
-
-* Demo data has lost the tags at some point
-
-* Tag cloud and tag list pages show (and count) tags on hidden content
-
-* Investigate alternatives to Blazer?
-    * https://github.com/ankane/blazer/pull/316 :(
-
-* Blazer currently doesn't restrict people without 'edit' capability to view-only
-
-* Delete ahoy and session data when Akismet reports blatant spam? (make configurable)
-
 * Finish adding support for links on user profiles
 
 * Add 'items' extra to Pagy: https://ddnexus.github.io/pagy/extras/items.html
     * Allow pagination URLs to specify /items/N instead of ?items=N
+
+* Tag cloud and tag list pages show (and count) tags on hidden content
+
+* Blazer:
+    * Investigate alternatives? https://github.com/ankane/blazer/pull/316 :(
+    * Fix admin ACL; currently if you can view, you can add/update/delete too
+
+* Various email-sending tests (Forms, Newsletters, etc) throw this when run offline:
+    * "Mjml: warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."
+    * Newsletter plugin tests tend to top the 'slowest tests' list - related?
+
+* Delete ahoy and session data when Akismet reports blatant spam? (make configurable)
 
 
 ## Features the Perl version has, which the Ruby version doesn't. Yet. :)

--- a/docs/Developers/TODO.md
+++ b/docs/Developers/TODO.md
@@ -11,6 +11,7 @@
 
 * Blazer:
     * Investigate alternatives? https://github.com/ankane/blazer/pull/316 :(
+        * daru-view ?? https://github.com/SciRuby/daru-view#readme
     * Fix admin ACL; currently if you can view, you can add/update/delete too
 
 * Various email-sending tests (Forms, Newsletters, etc) throw this when run offline:


### PR DESCRIPTION
This was left out before to make Travis CI multi-ruby-version job work, but as they are no longer relevant...

Re-adding this means that Heroku actually uses the correct version of Ruby now, yay (they ignore .ruby-version for some reason).