### PR TITLE
Some improvements to rspec config

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--require spec_helper
+--require rspec/instafail
+--format RSpec::Instafail
+--format progress

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,2 +1,4 @@
 --format progress
---format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::RuntimeLogger  --out tmp/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log
+--format ParallelTests::RSpec::SummaryLogger  --out tmp/spec_summary.log

--- a/Gemfile
+++ b/Gemfile
@@ -176,7 +176,7 @@ source 'https://rubygems.org' do
     gem 'fasterer', require: false
 
     # Best practices
-    gem 'rails_best_practices'
+    gem 'rails_best_practices', require: false
 
     # Ruby Critic generates easy-to-read reports from multiple static analysis tools
     gem 'rubycritic', '~> 4.6.0', require: false
@@ -214,5 +214,8 @@ source 'https://rubygems.org' do
     gem 'codecov', require: false
     # Rspec report formatter for Codecov
     gem 'rspec_junit_formatter'
+
+    # Show test failure details instantly, in-line with progress dots
+    gem 'rspec-instafail'
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,11 +514,17 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
+    rspec-instafail (1.0.0)
+      rspec
     rspec-mocks (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
@@ -705,6 +711,7 @@ DEPENDENCIES
   rails_best_practices!
   rails_email_preview!
   recaptcha!
+  rspec-instafail!
   rspec-rails!
   rspec_junit_formatter!
   rss!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,11 +44,17 @@ RSpec.configure do |config|
     # has already been configured (e.g. via a command-line flag).
     config.default_formatter = 'doc'
   else
+    # This setting specifies which spec files to load when `rspec` is run without
+    # filename arguments. The default value is just the spec files in the main app's
+    # spec/ directory. The pattern below also loads the spec files from each plugin.
+    config.pattern = '**/*_spec.rb,../plugins/*/spec/**/*_spec.rb'
+
     # Only overwrite coverage when running the full test suite
     SimpleCov.start do
       add_filter '/spec/'
     end
 
+    # We can only be in CI if we're running the whole suite
     if ENV['CI'] == 'true'
       require 'codecov'
       SimpleCov.formatter = SimpleCov::Formatter::Codecov

--- a/tools/bundle-install
+++ b/tools/bundle-install
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # ShinyCMS ~ https://shinycms.org
 #
 # Copyright 2009-2021 Denny de la Haye ~ https://denny.me

--- a/tools/heroku-release
+++ b/tools/heroku-release
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # ShinyCMS ~ https://shinycms.org
 #
 # Copyright 2009-2021 Denny de la Haye ~ https://denny.me

--- a/tools/parallel-rspec
+++ b/tools/parallel-rspec
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # ShinyCMS ~ https://shinycms.org
 #
 # Copyright 2009-2021 Denny de la Haye ~ https://denny.me
@@ -10,4 +8,4 @@
 #
 # Not used on CircleCI because that has its own parallelisation thing going on.
 
-parallel_rspec spec/ plugins/
+parallel_rspec --first-is-1 spec/ plugins/

--- a/tools/sidekiq-dev
+++ b/tools/sidekiq-dev
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # ShinyCMS ~ https://shinycms.org
 #
 # Copyright 2009-2021 Denny de la Haye ~ https://denny.me


### PR DESCRIPTION
* Fix rspec config so the bare `rspec` command will run the plugin tests as well as the main app tests
* Output failure details immediately during test runs, inline with the progress dots, as well as at the end of the run ("Fail early! Fail often!")
* Create more log files when running `tools/parallel-rspec` (failure log and summary log as well as timing log)
