### PR TITLE
Drop all URLs ending in .php

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     # Currently, if ShinyPages is loaded, then we assume it should control the root path
     import_routes partial: :root, plugin: :ShinyPages if ShinyCMS.plugins.loaded? :ShinyPages
 
+    import_routes partial: :php_is_a_bad_request
+
     import_routes partial: :mount_shinycms_core_plugin
 
     import_routes partial: :mount_shinycms_feature_plugins

--- a/plugins/ShinyCMS/app/controllers/shinycms/errors_controller.rb
+++ b/plugins/ShinyCMS/app/controllers/shinycms/errors_controller.rb
@@ -9,6 +9,10 @@
 module ShinyCMS
   # Smarter error pages
   class ErrorsController < MainController
+    def bad_request
+      head :bad_request
+    end
+
     def not_found
       render status: :not_found
     end

--- a/plugins/ShinyCMS/config/routes/php_is_a_bad_request.rb
+++ b/plugins/ShinyCMS/config/routes/php_is_a_bad_request.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2021 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Give requests for .php URLs the love and respect they deserve
+
+match '*anything_ending_in.php', to: 'shinycms/errors#bad_request', as: :php_is_a_bad_request, via: :all

--- a/plugins/ShinyCMS/spec/requests/shinycms/errors_controller_spec.rb
+++ b/plugins/ShinyCMS/spec/requests/shinycms/errors_controller_spec.rb
@@ -10,6 +10,16 @@ require 'rails_helper'
 
 # Tests for ShinyCMS error handlers
 RSpec.describe ShinyCMS::ErrorsController, type: :request do
+  describe 'GET /wp-login.php (or any URL ending in .php)', :production_error_responses do
+    it 'returns a 400 (Bad Request) error - headers only, to keep it light' do
+      get '/wp-login.php'
+
+      expect( response ).to have_http_status :bad_request
+
+      expect( response.body ).to be_blank
+    end
+  end
+
   describe 'GET /no-such-path', :production_error_responses do
     it 'returns our Not Found page, with a 404 status' do
       get '/no-such-path'


### PR DESCRIPTION
(Wordpress h4xx0rz trollolol oh god my logs)

I put the route immediately after the root path in the main routes file. Your priorities may differ.

This catches anything ending in .php ... which mostly means script kiddies looking for unsecured Wordpress installs.

It returns a headers-only 400 (bad request) error, for minimum cost to us.