### PR TITLE
Rewrite demo data load order config methods

### DIFF
--- a/plugins/ShinyCMS/app/models/concerns/shinycms/element.rb
+++ b/plugins/ShinyCMS/app/models/concerns/shinycms/element.rb
@@ -29,10 +29,11 @@ module ShinyCMS
       def format_name
         self.name = name.parameterize.underscore
       end
+    end
 
-      # Elements of templated items need to be inserted after the related Template, Template Elements, and item
-      def self.demo_data_position
-        4 unless include? ShinyCMS::TemplateElement
+    class_methods do
+      def my_demo_data_position
+        4  # template, template's elements, templated item, templated item's elements
       end
     end
   end

--- a/plugins/ShinyCMS/app/models/concerns/shinycms/has_template.rb
+++ b/plugins/ShinyCMS/app/models/concerns/shinycms/has_template.rb
@@ -34,9 +34,11 @@ module ShinyCMS
       def elements_hash
         elements.collect { |element| [ element.name.to_sym, ( element.image.presence || element.content ) ] }.to_h
       end
+    end
 
+    class_methods do
       # Templated resources need to be inserted after their Templates and their Template Elements
-      def self.demo_data_position
+      def my_demo_data_position
         3
       end
     end

--- a/plugins/ShinyCMS/app/models/concerns/shinycms/provides_demo_site_data.rb
+++ b/plugins/ShinyCMS/app/models/concerns/shinycms/provides_demo_site_data.rb
@@ -12,9 +12,13 @@ module ShinyCMS
     extend ActiveSupport::Concern
 
     class_methods do
-      # Default restore order, for anything that doesn't care
+      # Set the order in which data is loaded by `rails shinycms:demo:load`.
+      # Defaults to 'in the first batch', i.e. no dependencies on other data.
+      #
+      # Override per model with a class method `my_demo_data_position`, that
+      # returns an integer higher than any of the models it depends on.
       def demo_data_position
-        1
+        try( :my_demo_data_position ) || 1
       end
     end
   end

--- a/plugins/ShinyCMS/app/models/concerns/shinycms/template_element.rb
+++ b/plugins/ShinyCMS/app/models/concerns/shinycms/template_element.rb
@@ -19,10 +19,11 @@ module ShinyCMS
       acts_as_list scope: :template
 
       validates :template, presence: true
+    end
 
-      # Template Elements need to be inserted after Templates
-      def self.demo_data_position
-        2
+    class_methods do
+      def my_demo_data_position
+        2  # Template Elements need to be inserted after Templates
       end
     end
   end

--- a/plugins/ShinyCMS/app/models/shinycms/comment.rb
+++ b/plugins/ShinyCMS/app/models/shinycms/comment.rb
@@ -105,7 +105,7 @@ module ShinyCMS
           .order( posted_at: :desc )
     end
 
-    def self.demo_data_position
+    def self.my_demo_data_position
       11  # after discussions
     end
   end

--- a/plugins/ShinyCMS/app/models/shinycms/discussion.rb
+++ b/plugins/ShinyCMS/app/models/shinycms/discussion.rb
@@ -73,8 +73,8 @@ module ShinyCMS
       [ discussions, counts ]
     end
 
-    def self.demo_data_position
-      10  # arbitrary 'probably after anything that might want comments on it' number
+    def self.my_demo_data_position
+      10  # hopefully higher than any content types that might have discussions attached
     end
   end
 end

--- a/plugins/ShinyCMS/app/models/shinycms/pseudonymous_author.rb
+++ b/plugins/ShinyCMS/app/models/shinycms/pseudonymous_author.rb
@@ -24,7 +24,7 @@ module ShinyCMS
       email_recipient.email
     end
 
-    def self.demo_data_position
+    def self.my_demo_data_position
       2  # after email recipients
     end
   end

--- a/plugins/ShinyNewsletters/app/models/shiny_newsletters/send.rb
+++ b/plugins/ShinyNewsletters/app/models/shiny_newsletters/send.rb
@@ -90,7 +90,7 @@ module ShinyNewsletters
         .order( sent_at: :desc )
     end
 
-    def self.demo_data_position
+    def self.my_demo_data_position
       5  # after templates, template elements, editions, and edition elements
     end
   end

--- a/plugins/ShinyPages/spec/factories/shiny_pages/template_elements.rb
+++ b/plugins/ShinyPages/spec/factories/shiny_pages/template_elements.rb
@@ -11,6 +11,8 @@ module ShinyPages
   FactoryBot.define do
     factory :page_template_element, class: 'ShinyPages::TemplateElement' do
       name { Faker::Books::CultureSeries.unique.civs.underscore }
+
+      association :template, factory: :page_template
     end
   end
 end

--- a/plugins/ShinyPages/spec/models/shiny_pages/template_element_spec.rb
+++ b/plugins/ShinyPages/spec/models/shiny_pages/template_element_spec.rb
@@ -13,8 +13,7 @@ module ShinyPages
   RSpec.describe TemplateElement, type: :model do
     describe 'concerns' do
       it_behaves_like ShinyCMS::Element do
-        let( :template ) { create :page_template                             }
-        let( :element  ) { create :page_template_element, template: template }
+        let( :element ) { create :page_template_element }
       end
 
       it_behaves_like ShinyCMS::ProvidesDemoSiteData do

--- a/plugins/ShinyProfiles/app/models/shiny_profiles/link.rb
+++ b/plugins/ShinyProfiles/app/models/shiny_profiles/link.rb
@@ -28,7 +28,7 @@ module ShinyProfiles
 
     delegate :hidden?, to: :profile
 
-    def self.demo_data_position
+    def self.my_demo_data_position
       2  # after profiles
     end
   end


### PR DESCRIPTION
Something wasn't quite working right in the previous incarnation of this (relating to module load order, I think). I've rewritten it to use a different method name for the override method and the default method, so that part of it is more explicit about what it's doing now.