### PR TITLE
Refactor build_plugins_from_names method

### DIFF
--- a/plugins/ShinyCMS/app/models/concerns/shinycms/has_tags.rb
+++ b/plugins/ShinyCMS/app/models/concerns/shinycms/has_tags.rb
@@ -15,7 +15,7 @@ module ShinyCMS
     included do
       # Create two contexts; one for normal tags, one to stash hidden tags in
 
-      acts_as_taggable_on :tags, :hidden_tags
+      acts_as_ordered_taggable_on :tags, :hidden_tags
 
       # Adjust show/hide context for tags based on resource show/hide status
 

--- a/plugins/ShinyCMS/app/models/shinycms/plugins.rb
+++ b/plugins/ShinyCMS/app/models/shinycms/plugins.rb
@@ -95,12 +95,11 @@ module ShinyCMS
       raise ArgumentError, "Required: valid plugin names, or ShinyCMS::Plugin objects. Received: #{new_plugins}"
     end
 
-    def build_plugins_from_names( to_build )
-      names = to_build.all?( String ) ? to_build.collect( &:to_sym ) : to_build
-      return unless names.all?( Symbol )
-
-      # Wouldn't need .to_a here if a💎 supported .intersection (or &)
-      💎ify[ names.to_a.intersection( Plugins.all_plugin_names ).collect { |plugin| ShinyCMS::Plugin.get( plugin ) } ]
+    def build_plugins_from_names( requested_names )
+      # We need .to_a on the end of the first line because a💎 doesn't have .intersection (or &)
+      names_to_symbols = requested_names.collect( &:to_s ).collect( &:to_sym ).to_a
+      names_that_exist = names_to_symbols.intersection( Plugins.all_plugin_names )
+      💎ify[ names_that_exist.collect { |name| ShinyCMS::Plugin.get( name ) } ]
     end
   end
 end

--- a/plugins/ShinyCMS/app/models/shinycms/plugins.rb
+++ b/plugins/ShinyCMS/app/models/shinycms/plugins.rb
@@ -96,10 +96,19 @@ module ShinyCMS
     end
 
     def build_plugins_from_names( requested_names )
-      # We need .to_a on the end of the first line because a💎 doesn't have .intersection (or &)
-      names_to_symbols = requested_names.collect( &:to_s ).collect( &:to_sym ).to_a
-      names_that_exist = names_to_symbols.intersection( Plugins.all_plugin_names )
+      names_as_symbols = coerce_to_symbols( requested_names )
+      names_that_exist = check_against_filenames( names_as_symbols )
+
       💎ify[ names_that_exist.collect { |name| ShinyCMS::Plugin.get( name ) } ]
+    end
+
+    def coerce_to_symbols( requested_names )
+      requested_names.collect( &:to_s ).collect( &:to_sym )
+    end
+
+    def check_against_filenames( requested_names )
+      # We need .to_a here because a💎 doesn't have .intersection (or &)
+      requested_names.to_a.intersection( Plugins.all_plugin_names )
     end
   end
 end

--- a/plugins/ShinyCMS/spec/controllers/concerns/shinycms/admin/tags_spec.rb
+++ b/plugins/ShinyCMS/spec/controllers/concerns/shinycms/admin/tags_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe ShinyCMS::Admin::Tags, type: :request do
   describe 'GET /admin/blog/:id/edit' do
     context 'when a visible blog post has tags' do
       it 'they load on its edit page' do
-        skip 'FIXME: fails on CI but not locally'
-
         post = create :blog_post, tag_list: 'test, tag, list'
 
         expect( post.tag_list.present?        ).to be true
@@ -34,8 +32,6 @@ RSpec.describe ShinyCMS::Admin::Tags, type: :request do
 
     context 'when a hidden blog post has tags' do
       it 'they load on its edit page' do
-        skip 'FIXME: fails on CI but not locally'
-
         post = create :blog_post, tag_list: 'test, tag, list'
         post.update!( show_on_site: false )
 


### PR DESCRIPTION
I got this down to an admittedly action-packed (AKA dense, bordering on obfuscated) three line method which was a continuous chain of method calls. Ruby Critic said it was too complex.

So I split that into three methods, one for each line more or less. Ruby Critic said they were too trivial. 😝 

I kept the version with three methods, because I quite liked how the method names and variable names had ended up. One bot's trivial is another man's 'easy to reason about', right? 😉  

Also, I jammed the acts-as-taggable-on fix into this branch because I am a terrible person. It wasn't actually set to preserve order, I must have just got lucky up to now? Weirdness. Anyway, should be sorted now.