### PR TITLE
Methods to identify each comment author type

### DIFF
--- a/plugins/ShinyCMS/app/models/shinycms/comment.rb
+++ b/plugins/ShinyCMS/app/models/shinycms/comment.rb
@@ -77,6 +77,14 @@ module ShinyCMS
       author.is_a? ShinyCMS::User
     end
 
+    def pseudonymous_author?
+      author.is_a? ShinyCMS::PseudonymousAuthor
+    end
+
+    def anonymous_author?
+      author.is_a? ShinyCMS::AnonymousAuthor
+    end
+
     def notification_email
       author.email
     end

--- a/plugins/ShinyCMS/app/views/shinycms/discussions/comment/_posted_by.html.erb
+++ b/plugins/ShinyCMS/app/views/shinycms/discussions/comment/_posted_by.html.erb
@@ -1,13 +1,13 @@
 Posted by
-<% if comment.author.blank? %>
-  <%= t( 'shinycms.discussions.anonymous' ) %>
-<% elsif comment.authenticated_author? %>
+<% if comment.authenticated_author? %>
     <%= user_profile_link( comment.author ) %>
-<% else %>
+<% elsif comment.pseudonymous_author? %>
   <% if comment.author.url.present? %>
     <%= link_to comment.author.name, comment.author.url %>
   <% else %>
     <%= comment.author.name %>
   <% end %>
+<% elsif comment.anonymous_author? %>
+  <%= t( 'shinycms.discussions.anonymous' ) %>
 <% end %>
 at <%= display_time_on_date( comment.posted_at ) %>


### PR DESCRIPTION
Methods in comments model, being used in discussion/comment partials. Fixes a couple of errors that have been coming up on shinycms.org this week...