### PR TITLE
April 2021: The 'Respecting Boundaries' release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@
 
 require_relative 'lib/gemfile_plugins_helper'
 
-source 'https://rubygems.org' do
-  # Ruby 3.0
-  ruby '~> 3.0.1'
+# Ruby 3.0
+ruby '~> 3.0.1'
 
+source 'https://rubygems.org' do
   # Rails 6.1
   gem 'rails', '~> 6.1.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: plugins/ShinyAccess
   specs:
-    shiny_access (21.03)
+    shiny_access (21.04)
       acts-as-taggable-on
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
@@ -13,7 +13,7 @@ PATH
 PATH
   remote: plugins/ShinyBlog
   specs:
-    shiny_blog (21.03)
+    shiny_blog (21.04)
       acts-as-taggable-on
       acts_as_paranoid
       ckeditor
@@ -26,7 +26,7 @@ PATH
 PATH
   remote: plugins/ShinyCMS
   specs:
-    shinycms (21.03)
+    shinycms (21.04)
       activerecord-session_store
       acts-as-taggable-on
       acts_as_list
@@ -66,7 +66,7 @@ PATH
 PATH
   remote: plugins/ShinyForms
   specs:
-    shiny_forms (21.03)
+    shiny_forms (21.04)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
       pagy
@@ -77,7 +77,7 @@ PATH
 PATH
   remote: plugins/ShinyInserts
   specs:
-    shiny_inserts (21.03)
+    shiny_inserts (21.04)
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
@@ -89,7 +89,7 @@ PATH
 PATH
   remote: plugins/ShinyLists
   specs:
-    shiny_lists (21.03)
+    shiny_lists (21.04)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
       pagy
@@ -100,7 +100,7 @@ PATH
 PATH
   remote: plugins/ShinyNews
   specs:
-    shiny_news (21.03)
+    shiny_news (21.04)
       acts-as-taggable-on
       acts_as_paranoid
       ckeditor
@@ -113,7 +113,7 @@ PATH
 PATH
   remote: plugins/ShinyNewsletters
   specs:
-    shiny_newsletters (21.03)
+    shiny_newsletters (21.04)
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
@@ -125,7 +125,7 @@ PATH
 PATH
   remote: plugins/ShinyPages
   specs:
-    shiny_pages (21.03)
+    shiny_pages (21.04)
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
@@ -137,7 +137,7 @@ PATH
 PATH
   remote: plugins/ShinyProfiles
   specs:
-    shiny_profiles (21.03)
+    shiny_profiles (21.04)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
       pagy
@@ -148,7 +148,7 @@ PATH
 PATH
   remote: plugins/ShinySEO
   specs:
-    shiny_seo (21.03)
+    shiny_seo (21.04)
       pg (>= 0.18, < 2.0)
       rails (~> 6.1.2, >= 6.1.2.1)
       sitemap_generator
@@ -156,7 +156,7 @@ PATH
 PATH
   remote: plugins/ShinySearch
   specs:
-    shiny_search (21.03)
+    shiny_search (21.04)
       acts-as-taggable-on
       acts_as_paranoid
       algoliasearch-rails
@@ -170,6 +170,135 @@ PATH
 
 GEM
   specs:
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
+    acts_as_list (1.0.3)
+      activerecord (>= 4.2)
+    acts_as_votable (0.13.1)
+    airbrake (11.0.1)
+      airbrake-ruby (~> 5.1)
+    airbrake-ruby (5.2.0)
+      rbtree3 (~> 0.5)
+    akismet (3.0.0)
+    algoliasearch (1.27.5)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    algoliasearch-rails (1.25.0)
+      algoliasearch (>= 1.26.0, < 2.0.0)
+      json (>= 1.5.1)
+    amazing_print (1.3.0)
+    aws-eventstream (1.1.1)
+    aws-partitions (1.442.0)
+    aws-sdk-core (3.113.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.43.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.93.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+    bcrypt (3.1.16)
+    bugsnag (6.20.0)
+      concurrent-ruby (~> 1.0)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
+    cloudflare-rails (2.0.0)
+      actionpack (>= 5.0, < 6.2.0)
+      activesupport (>= 5.0, < 6.2.0)
+      httparty
+      railties (>= 5.0, < 6.2.0)
+    coderay (1.1.3)
+    connection_pool (2.2.3)
+    devise (4.7.3)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise-pwned_password (0.1.9)
+      devise (~> 4)
+      pwned (~> 2.0.0)
+    email_address (0.1.20)
+      netaddr (>= 2.0.4, < 3)
+      simpleidn
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    httpclient (2.8.3)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
+    jmespath (1.4.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
+    mini_magick (4.11.0)
+    mjml-rails (4.6.1)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    netaddr (2.0.4)
+    numerizer (0.1.1)
+    persistent-dmnd (2.0.2)
+      hamster (~> 3.0)
+    pg_search (2.3.5)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
+    pry (0.14.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
+    pwned (2.0.2)
+    rack-proxy (0.6.5)
+      rack
+    rbtree3 (0.6.0)
+    recaptcha (5.7.0)
+      json
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
+    rss (0.2.9)
+      rexml
+    ruby-vips (2.1.0)
+      ffi (~> 1.12)
+    seed_dump (3.3.1)
+      activerecord (>= 4)
+      activesupport (>= 4)
+    semantic_range (3.0.0)
+    sidekiq (6.2.0)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
+    sidekiq-status (1.1.4)
+      chronic_duration
+      sidekiq (>= 3.0)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
+    sitemap_generator (6.1.2)
+      builder (~> 3.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
+    warden (1.2.9)
+      rack (>= 2.0.9)
+    webpacker (5.2.1)
+      activesupport (>= 5.2)
+      rack-proxy (>= 0.6.1)
+      railties (>= 5.2)
+      semantic_range (>= 2.3.0)
+    zxcvbn-ruby (1.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -222,12 +351,6 @@ GEM
       activesupport (= 6.1.3.1)
     activerecord-analyze (0.6.0)
       rails (>= 5.1.0)
-    activerecord-session_store (2.0.0)
-      actionpack (>= 5.2.4.1)
-      activerecord (>= 5.2.4.1)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 2.0.8, < 3)
-      railties (>= 5.2.4.1)
     activestorage (6.1.3.1)
       actionpack (= 6.1.3.1)
       activejob (= 6.1.3.1)
@@ -243,12 +366,9 @@ GEM
       zeitwerk (~> 2.3)
     acts-as-taggable-on (7.0.0)
       activerecord (>= 5.0, < 6.2)
-    acts_as_list (1.0.3)
-      activerecord (>= 4.2)
     acts_as_paranoid (0.7.1)
       activerecord (>= 5.2, < 7.0)
       activesupport (>= 5.2, < 7.0)
-    acts_as_votable (0.13.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ahoy_email (1.1.1)
@@ -261,40 +381,11 @@ GEM
       device_detector
       geocoder (>= 1.4.5)
       safely_block (>= 0.2.1)
-    airbrake (11.0.1)
-      airbrake-ruby (~> 5.1)
-    airbrake-ruby (5.2.0)
-      rbtree3 (~> 0.5)
-    akismet (3.0.0)
-    algoliasearch (1.27.5)
-      httpclient (~> 2.8, >= 2.8.3)
-      json (>= 1.5.1)
-    algoliasearch-rails (1.25.0)
-      algoliasearch (>= 1.26.0, < 2.0.0)
-      json (>= 1.5.1)
-    amazing_print (1.3.0)
     ast (2.4.2)
-    aws-eventstream (1.1.1)
-    aws-partitions (1.442.0)
-    aws-sdk-core (3.113.1)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.239.0)
-      aws-sigv4 (~> 1.1)
-      jmespath (~> 1.0)
-    aws-sdk-kms (1.43.0)
-      aws-sdk-core (~> 3, >= 3.112.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.93.0)
-      aws-sdk-core (~> 3, >= 3.112.0)
-      aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.2.3)
-      aws-eventstream (~> 1, >= 1.0.2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    bcrypt (3.1.16)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -309,8 +400,6 @@ GEM
       railties (>= 5)
       safely_block (>= 0.1.1)
     brakeman (5.0.0)
-    bugsnag (6.20.0)
-      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     bullet (6.1.4)
       activesupport (>= 3.0.0)
@@ -328,24 +417,15 @@ GEM
       xpath (~> 3.2)
     chartkick (4.0.2)
     childprocess (4.0.0)
-    chronic_duration (0.10.6)
-      numerizer (~> 0.1.1)
     ckeditor (5.1.0)
       orm_adapter (~> 0.5.0)
-    cloudflare-rails (2.0.0)
-      actionpack (>= 5.0, < 6.2.0)
-      activesupport (>= 5.0, < 6.2.0)
-      httparty
-      railties (>= 5.0, < 6.2.0)
     code_analyzer (0.5.2)
       sexp_processor
     codecov (0.5.1)
       simplecov (>= 0.15, < 0.22)
-    coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.8)
-    connection_pool (2.2.3)
     constant_resolver (0.1.5)
     coverband (5.1.0)
       redis
@@ -359,24 +439,12 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     device_detector (1.0.5)
-    devise (4.7.3)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
-      responders
-      warden (~> 1.2.3)
-    devise-pwned_password (0.1.9)
-      devise (~> 4)
-      pwned (~> 2.0.0)
     diff-lcs (1.4.4)
     docile (1.3.5)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    email_address (0.1.20)
-      netaddr (>= 2.0.4, < 3)
-      simpleidn
     equalizer (0.0.11)
     errbase (0.2.1)
     erubi (1.10.0)
@@ -401,15 +469,9 @@ GEM
     geocoder (1.6.6)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    hamster (3.0.0)
-      concurrent-ruby (~> 1.0)
     hashdiff (1.0.1)
     highline (2.0.3)
     html_tokenizer (0.0.7)
-    httparty (0.18.1)
-      mime-types (~> 3.0)
-      multi_xml (>= 0.5.2)
-    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.34)
@@ -423,11 +485,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
-    image_processing (1.12.1)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     iniparse (1.5.0)
-    jmespath (1.4.0)
     json (2.5.1)
     kwalify (0.7.2)
     launchy (2.5.0)
@@ -448,22 +506,13 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
-    mini_magick (4.11.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
-    mjml-rails (4.6.1)
-    multi_json (1.15.0)
-    multi_xml (0.6.0)
-    netaddr (2.0.4)
     nio4r (2.5.7)
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    numerizer (0.1.1)
     orm_adapter (0.5.0)
     overcommit (0.57.0)
       childprocess (>= 0.6.3, < 5)
@@ -482,28 +531,15 @@ GEM
     parser (3.0.1.0)
       ast (~> 2.4.1)
     path_expander (1.1.0)
-    persistent-dmnd (2.0.2)
-      hamster (~> 3.0)
     pg (1.2.3)
-    pg_search (2.3.5)
-      activerecord (>= 5.2)
-      activesupport (>= 5.2)
-    pry (0.14.0)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     psych (3.3.1)
     public_suffix (4.0.6)
     puma (5.2.2)
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
-    pwned (2.0.2)
     racc (1.5.2)
     rack (2.2.3)
-    rack-proxy (0.6.5)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.3.1)
@@ -556,9 +592,6 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbtree3 (0.6.0)
-    recaptcha (5.7.0)
-      json
     redis (4.2.5)
     reek (6.0.3)
       kwalify (~> 0.7.0)
@@ -569,9 +602,6 @@ GEM
     request_store (1.5.0)
       rack (>= 1.4)
     require_all (3.0.0)
-    responders (3.0.1)
-      actionpack (>= 5.0)
-      railties (>= 5.0)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -598,8 +628,6 @@ GEM
     rspec-support (3.10.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rss (0.2.9)
-      rexml
     rubocop (1.12.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -625,8 +653,6 @@ GEM
       pg
       terminal-table
     ruby-progressbar (1.11.0)
-    ruby-vips (2.1.0)
-      ffi (~> 1.12)
     ruby_parser (3.15.1)
       sexp_processor (~> 4.9)
     rubycritic (4.6.1)
@@ -650,28 +676,13 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    seed_dump (3.3.1)
-      activerecord (>= 4)
-      activesupport (>= 4)
-    semantic_range (3.0.0)
     sexp_processor (4.15.2)
-    sidekiq (6.2.0)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.2.0)
-    sidekiq-status (1.1.4)
-      chronic_duration
-      sidekiq (>= 3.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    simpleidn (0.2.1)
-      unf (~> 0.1.4)
-    sitemap_generator (6.1.2)
-      builder (~> 3.0)
     smart_properties (1.15.0)
     sorbet-runtime (0.5.6366)
     sprockets (4.0.2)
@@ -692,9 +703,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     uniform_notifier (1.14.2)
     virtus (1.0.5)
@@ -702,24 +710,16 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.9)
-      rack (>= 2.0.9)
     webmock (3.12.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webpacker (5.2.1)
-      activesupport (>= 5.2)
-      rack-proxy (>= 0.6.1)
-      railties (>= 5.2)
-      semantic_range (>= 2.3.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
-    zxcvbn-ruby (1.2.0)
 
 PLATFORMS
   ruby

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -8,9 +8,10 @@
 
 # This version number is specifically for the ShinyHostApp
 
-# Each ShinyCMS plugin has its own version number; the core plugin is currently at version 21.03
+# Each ShinyCMS plugin has its own version number
+# The core plugin is currently at version 21.04
 
 module ShinyHostApp
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/docs/Developers/Plugins.md
+++ b/docs/Developers/Plugins.md
@@ -50,9 +50,11 @@ Helpers:
 * Methods in `ShinyThing/app/helper/shiny_thing/MainSiteHelper.rb` will be available to all main site views, not just those rendered by your plugin's controllers
 
 
-### Boundaries, or Avoiding Tight Coupling
+### Boundaries
 
-ShinyCMS uses a gem called [Packwerk](https://github.com/shopify/packwerk#readme) to check on coupling across architectural boundaries. The short version is that you should only be using interfaces exposed as public by other plugins that you have explicitly declared a dependency on, rather than 'reaching into the middle' of other plugins or depending on them unexpectedly.
+ShinyCMS uses a gem called [Packwerk](https://github.com/shopify/packwerk#readme) to check on coupling across architectural boundaries.
+
+The short version is that you should only be using interfaces exposed as public by other plugins that you have explicitly declared a dependency on, rather than 'reaching into the middle' of other plugins or depending on them unexpectedly.
 
 The core ShinyCMS plugin has quite a lot of exposed interfaces for your plugin to leverage; base controllers you can inherit from, concerns and helpers you can use, etc etc. You can find all of this code in its `app/public` directory. Most other plugins will have far less public code exposed, as the idea is to keep them independent of each other as much possible, so that people only have to enable the ones that they want to use for a particular site.
 
@@ -63,4 +65,4 @@ The command `bin/packwerk validate` will check to make sure those `package.yml` 
 
 ### Share and Enjoy!
 
-If possible, please share your plugin with other ShinyCMS users by making a PR back to the main ShinyCMS-ruby repo on GitHub :)
+If possible, please share your plugin with other ShinyCMS users, by making a PR back to the main ShinyCMS-ruby repo on GitHub! :)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,12 +4,52 @@
 
 This file contains information about changes (particularly breaking changes) between releases - with the most recent release first.
 
+### 2021-04-08  21.04  April 2021: The 'Respecting Boundaries' release
+
+    * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.04
+
+    * Headline for this release:
+        * [Packwerk](https://github.com/Shopify/packwerk/blob/main/README.md)
+            * Define and enforce [plugin boundaries](https://github.com/denny/ShinyCMS-ruby/tree/main/docs/Developers/Plugins.md#boundaries)
+
+    * Also added:
+        * Routes partials - building blocks for routes files
+            * Intended to be useful for integrating ShinyCMS with pre-existing Rails apps
+        * Bullet (warns about N+1 queries and related issues)
+        * CircleCI config for Code Climate coverage reporting
+        * Hugely improved base class for Mailers to inherit from
+            * Again, should aid integration work, and legal compliance
+        * Items extension for Pagy
+        * As well as Packwerk config files in each plugin, there is currently a `deprecated_references.yml` file, which is similar to `rubocop_todo.yml` - it contains known boundary violations in the current code that should be fixed in the code and then removed from the file
+        * Some new classes have been added to enable plugins to talk to each other without violating boundaries, but mostly pre-existing helpers and concerns are handling this
+
+    * Moved:
+        * From main_app to core plugin:
+            * Most of the Gemfile
+            * Various config files
+            * rake tasks
+            * Rails Email Preview
+            * Base controllers used by gem Rails engines (e.g. Devise, Rails Email Preview, etc) (moved to ShinyCMS::Admin::Tools namespace)
+        * To app/public folders:
+            * Anything in one plugin (mostly ShinyCMS) that is used by another plugin
+
+    * Updated:
+        * Base controllers used by gem Rails engines heavily rewritten for easier re-use
+        * Tiny bumps for Ruby (from 3.0.0 to 3.0.1) and Rails (6.1.3 to 6.1.3.1)
+        * Renamed `shiny:*` rake tasks to `shinycms:*`
+
+    * Removed:
+        * Gemfile.lock files from plugins
+        * Unused config files in main_app (anything that was all comments)
+        * Disabled two Code Climate tools - spellcheck was removed I think, and Markdown Lint and I disagree on the value of vertical whitespace for readability in documentation :)
+
+
 ### 2021-03-01  21.03  March 2021: The 'Yo dawg I herd u liek CMS' release
 
     * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.03
 
     * Headline for this release:
-        I moved almost all the code that was still in main_app, into a plugin! :-o
+        * I moved almost all the code that was still in main_app, into a plugin! :-o
 
     * Done:
         * The main_app is now called ShinyHostApp, and eventually it's _only_ job will be to load plugins - to demonstrate how (eventually) ShinyCMS could potentially be integrated within any existing Rails app

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,390 +6,392 @@ This file contains information about changes (particularly breaking changes) bet
 
 ### 2021-04-08  21.04  April 2021: The 'Respecting Boundaries' release
 
-    * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.04
+* GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.04
 
-    * Headline for this release:
-        * [Packwerk](https://github.com/Shopify/packwerk/blob/main/README.md)
-            * Define and enforce [plugin boundaries](https://github.com/denny/ShinyCMS-ruby/tree/main/docs/Developers/Plugins.md#boundaries)
+* Headline for this release:
+    * Added [Packwerk](https://github.com/Shopify/packwerk/blob/main/README.md)
+        * Helps define and enforce [plugin boundaries](https://github.com/denny/ShinyCMS-ruby/tree/main/docs/Developers/Plugins.md#boundaries)
 
-    * Also added:
-        * Routes partials - building blocks for routes files
-            * Intended to be useful for integrating ShinyCMS with pre-existing Rails apps
-        * Bullet (warns about N+1 queries and related issues)
-        * CircleCI config for Code Climate coverage reporting
-        * Hugely improved base class for Mailers to inherit from
-            * Again, should aid integration work, and legal compliance
-        * Items extension for Pagy
-        * As well as Packwerk config files in each plugin, there is currently a `deprecated_references.yml` file, which is similar to `rubocop_todo.yml` - it contains known boundary violations in the current code that should be fixed in the code and then removed from the file
-        * Some new classes have been added to enable plugins to talk to each other without violating boundaries, but mostly pre-existing helpers and concerns are handling this
+* Also added:
+    * Routes partials - building blocks for routes files
+        * Intended to help with integrating ShinyCMS into pre-existing Rails apps
+    * Bullet (warns about N+1 queries and related issues)
+    * CircleCI config for Code Climate coverage reporting
+    * Hugely improved base class for Mailers to inherit from
+        * Again, should aid integration work, and legal compliance
+    * Items extension for Pagy
+    * `deprecated_references.yml`, which is Packwerk's equivalent of `rubocop_todo.yml`
+        * Contains known boundary violations in the current code
+        * These should be fixed in the code and then removed from the file
+    * Some new classes have been added to enable plugins to talk to each other without violating boundaries, but mostly pre-existing helpers and concerns are handling this
 
-    * Moved:
-        * From main_app to core plugin:
-            * Most of the Gemfile
-            * Various config files
-            * rake tasks
-            * Rails Email Preview
-            * Base controllers used by gem Rails engines (e.g. Devise, Rails Email Preview, etc) (moved to ShinyCMS::Admin::Tools namespace)
-        * To app/public folders:
-            * Anything in one plugin (mostly ShinyCMS) that is used by another plugin
+* Moved:
+    * From main_app to core plugin:
+        * Most of the Gemfile
+        * Some odds and ends of config (including main rubocop files)
+        * rake tasks
+        * Rails Email Preview
+        * Base controllers used by gem Rails engines (e.g. Devise, Rails Email Preview, etc) (moved to ShinyCMS::Admin::Tools namespace)
+    * To app/public folders:
+        * Anything in any plugin (mostly core) that is used by another plugin
 
-    * Updated:
-        * Base controllers used by gem Rails engines heavily rewritten for easier re-use
-        * Tiny bumps for Ruby (from 3.0.0 to 3.0.1) and Rails (6.1.3 to 6.1.3.1)
-        * Renamed `shiny:*` rake tasks to `shinycms:*`
+* Updated:
+    * Base controllers used by gem Rails engines heavily rewritten (for easier re-use)
+    * Tiny bumps for Ruby (from 3.0.0 to 3.0.1) and Rails (6.1.3 to 6.1.3.1)
+    * Renamed `shiny:*` rake tasks to `shinycms:*`
 
-    * Removed:
-        * Gemfile.lock files from plugins
-        * Unused config files in main_app (anything that was all comments)
-        * Disabled two Code Climate tools - spellcheck was removed I think, and Markdown Lint and I disagree on the value of vertical whitespace for readability in documentation :)
+* Removed:
+    * Gemfile.lock files from plugins
+    * Unused config files in main_app (anything that was all comments)
+    * Disabled two Code Climate tools - spellcheck was removed I think, and Markdown Lint and I disagree on the value of vertical whitespace for readability in documentation :)
 
 
 ### 2021-03-01  21.03  March 2021: The 'Yo dawg I herd u liek CMS' release
 
-    * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.03
+* GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.03
 
-    * Headline for this release:
-        * I moved almost all the code that was still in main_app, into a plugin! :-o
+* Headline for this release:
+    * I moved almost all the code that was still in main_app, into a plugin! :-o
 
-    * Done:
-        * The main_app is now called ShinyHostApp, and eventually it's _only_ job will be to load plugins - to demonstrate how (eventually) ShinyCMS could potentially be integrated within any existing Rails app
-        * The code that was in main_app is now in the new ShinyCMS core plugin, which you can find in `plugins/ShinyCMS`
-    * To-do:
-        * The config files haven't moved yet, that's my next big job
-        * The documentation is partially updated, but I haven't gone through it all yet, so there may well be discrepancies here there and everywhere
-        * Some of the engines from gems are still living in the main_app; a few of them didn't take well to being moved so I put them back there for now
+* Done:
+    * The main_app is now called ShinyHostApp, and eventually it's _only_ job will be to load plugins - to demonstrate how (eventually) ShinyCMS could potentially be integrated within any existing Rails app
+    * The code that was in main_app is now in the new ShinyCMS core plugin, which you can find in `plugins/ShinyCMS`
+* To-do:
+    * The config files haven't moved yet, that's my next big job
+    * The documentation is partially updated, but I haven't gone through it all yet, so there may well be discrepancies here there and everywhere
+    * Some of the engines from gems are still living in the main_app; a few of them didn't take well to being moved so I put them back there for now
 
-    * App and plugin versions:
-        * All of the feature plugins, the new ShinyCMS core plugin, and the sort-of new ShinyHostApp, have all had their versions updated to 21.03 in this release - because as you can probably imagine, everything has had quite a lot of changes this last month!
+* App and plugin versions:
+    * All of the feature plugins, the new ShinyCMS core plugin, and the sort-of new ShinyHostApp, have all had their versions updated to 21.03 in this release - because as you can probably imagine, everything has had quite a lot of changes this last month!
 
-    * Other significant stuff:
-        * I wrote a lot more code to support the Plugins 'infrastructure' or framework or whatever you'd call it. As well as the existing Plugin model (now ShinyCMS::Plugin, in the core plugin's models) there's also ShinyCMS::Plugins (plural) now - and a concern with some sugar/helper methods on top of that. All the code for dealing with collections of plugins moved into the new model, leaving the code that deals with individual plugins in the original class.
+* Other significant stuff:
+    * I wrote a lot more code to support the Plugins 'infrastructure' or framework or whatever you'd call it. As well as the existing Plugin model (now ShinyCMS::Plugin, in the core plugin's models) there's also ShinyCMS::Plugins (plural) now - and a concern with some sugar/helper methods on top of that. All the code for dealing with collections of plugins moved into the new model, leaving the code that deals with individual plugins in the original class.
 
-    * Annoying side-effects of the main_app -> ShinyCMS plugin migration
-        * A whole load of the moved files lost their git history at some point during the process; I guess GitHub decided that too many things had moved and so that must mean they'd all been deleted and new files created, despite the fact that I used the `git mv` command to do it all. I kept checking on things at the start and it was going okay, so I don't know what changed. I was quite a long way into the process when I did notice that it had dropped the history for a lot of stuff, so after a long pause to think it over, I decided to carry on rather than start again.
+* Annoying side-effects of the main_app -> ShinyCMS plugin migration
+    * A whole load of the moved files lost their git history at some point during the process; I guess GitHub decided that too many things had moved and so that must mean they'd all been deleted and new files created, despite the fact that I used the `git mv` command to do it all. I kept checking on things at the start and it was going okay, so I don't know what changed. I was quite a long way into the process when I did notice that it had dropped the history for a lot of stuff, so after a long pause to think it over, I decided to carry on rather than start again.
 
-    * Adventures in immutable data structures (and shiny emojis!)
-        * I decided to use the [Persistent Diamond(https://gitlab.com/ivoanjo/persistent-dmnd) set of immutable data structures to underpin the Plugin(s) models and concern, which comes complete with a shiny little diamond emoji scattered around in the code (it's part of the method names, as well as the module name). One of my co-workers hates it, but I'm quite enjoying it... brightens my days up a bit :)
+* Adventures in immutable data structures (and shiny emojis!)
+    * I decided to use the [Persistent Diamond(https://gitlab.com/ivoanjo/persistent-dmnd) set of immutable data structures to underpin the Plugin(s) models and concern, which comes complete with a shiny little diamond emoji scattered around in the code (it's part of the method names, as well as the module name). One of my co-workers hates it, but I'm quite enjoying it... brightens my days up a bit :)
 
-    * Also added:
-        * ShinySEO plugin; currently it just generates sitemap files (to feed into Google et al), but I already had some ideas for the future involving metatags helpers and concerns, so I figured an SEO plugin might be a good place for all that to end up.
-        * [parallel_tests](https://github.com/grosser/parallel_tests#readme) - run the tests spread evenly across all your CPUs!
-        * [rspec-instafail](https://github.com/grosser/rspec-instafail#readme) - displays fuller details of test failures while the rest of the suite continues to run in 'progress dots only' mode - so I can start on the fixes before it's even finished running :)
-        * [A GitHub project board](https://github.com/denny/ShinyCMS-ruby/projects/1), for task-tracking (instead of the TODO and in-progress files)
+* Also added:
+    * ShinySEO plugin; currently it just generates sitemap files (to feed into Google et al), but I already had some ideas for the future involving metatags helpers and concerns, so I figured an SEO plugin might be a good place for all that to end up.
+    * [parallel_tests](https://github.com/grosser/parallel_tests#readme) - run the tests spread evenly across all your CPUs!
+    * [rspec-instafail](https://github.com/grosser/rspec-instafail#readme) - displays fuller details of test failures while the rest of the suite continues to run in 'progress dots only' mode - so I can start on the fixes before it's even finished running :)
+    * [A GitHub project board](https://github.com/denny/ShinyCMS-ruby/projects/1), for task-tracking (instead of the TODO and in-progress files)
 
-    * Updated:
-        * LOTS OF DATABASE (TABLE NAME) CHANGES RELATED TO THE PLUGINIFICATION!!
-        * After moving everything into the ShinyCMS plugin, I removed the leading 'Shiny' from a lot of helper and concern names, as they're namespaced now anyway
-        * Made some changes around the comment-author area; it's a slightly more obvious role/duck-type now, with an AnonymousAuthor class joining in too
-        * Pulled most of the code out of the demo-data rake task into a supporting module, and broke it up into smaller methods. Still needs more tests though.
-        * I broke the plugin generator code up a bit too, but that's still pretty hideous. I got it down into the same complexity range as the rest of the system though, so it's not throwing the scale off in Ruby Critic's charts any more.
-        * Rails made its way from 6.1.1 to 6.1.3 over the month (with some security advisories involved I believe, so make sure you're up to date)
+* Updated:
+    * LOTS OF DATABASE (TABLE NAME) CHANGES RELATED TO THE PLUGINIFICATION!!
+    * After moving everything into the ShinyCMS plugin, I removed the leading 'Shiny' from a lot of helper and concern names, as they're namespaced now anyway
+    * Made some changes around the comment-author area; it's a slightly more obvious role/duck-type now, with an AnonymousAuthor class joining in too
+    * Pulled most of the code out of the demo-data rake task into a supporting module, and broke it up into smaller methods. Still needs more tests though.
+    * I broke the plugin generator code up a bit too, but that's still pretty hideous. I got it down into the same complexity range as the rest of the system though, so it's not throwing the scale off in Ruby Critic's charts any more.
+    * Rails made its way from 6.1.1 to 6.1.3 over the month (with some security advisories involved I believe, so make sure you're up to date)
 
-    * Removed:
-        * Got rid of quite a lot of instance variable warnings from rubocop for the spec files - although there are still well over a hundred to go!
-        * I both added _and_ removed the Airbrake gem; their free trial on Heroku turns out to be so feature-limited as to be useless. Coralogix and Bugsnag were both more impressive - Coralogix is very shiny, and Bugsnag has got some solid thinking behind it.
+* Removed:
+    * Got rid of quite a lot of instance variable warnings from rubocop for the spec files - although there are still well over a hundred to go!
+    * I both added _and_ removed the Airbrake gem; their free trial on Heroku turns out to be so feature-limited as to be useless. Coralogix and Bugsnag were both more impressive - Coralogix is very shiny, and Bugsnag has got some solid thinking behind it.
 
-    * Misc/stuff/FYI
-        * I currently have a temporary branch running parallel to main with Pry removed, as Heroku seem to have a problem with Pry right now (or more accurately, with the coderay gem that it requires); I'll reintegrate everything as soon as it seems safe.
+* Misc/stuff/FYI
+    * I currently have a temporary branch running parallel to main with Pry removed, as Heroku seem to have a problem with Pry right now (or more accurately, with the coderay gem that it requires); I'll reintegrate everything as soon as it seems safe.
 
 
 ### 2021-02-01  21.02  February 2021: The 'quiet after the storm' release
 
-    * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.02
+* GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.02
 
-    * Plugin versions all updated to 21.02, as they all have changes since 21.01
-        * Only minor changes in many though, often just the admin search method move
+* Plugin versions all updated to 21.02, as they all have changes since 21.01
+    * Only minor changes in many though, often just the admin search method move
 
-    * Headlines:
-        * Quiet month, after last month's upgrade extravaganza!
-        * No really big changes this month; not that many smaller ones either :)
+* Headlines:
+    * Quiet month, after last month's upgrade extravaganza!
+    * No really big changes this month; not that many smaller ones either :)
 
-    * Bug fixes:
-        * Tags on hidden content no longer show up on tag list and tag cloud pages
-            * Added ShinyTags concern and helpers to enable this
-        * User profile instantiation in dev is more robust now (lazy-loading issue resolved)
-        * More robust handling of 404s for non-HTML formats (usually hits from malware)
+* Bug fixes:
+    * Tags on hidden content no longer show up on tag list and tag cloud pages
+        * Added ShinyTags concern and helpers to enable this
+    * User profile instantiation in dev is more robust now (lazy-loading issue resolved)
+    * More robust handling of 404s for non-HTML formats (usually hits from malware)
 
-    * Added:
-        * ShinyUserAuthentication and ShinyUserAuthorization concerns
-            * Splitting out auth code from User model
-        * ShinyUserContent concern - splitting off relations to user-owned content
-        * Links on user profiles, with a JS UI that very nearly works properly
-        * ErrorController - more standard way to provide 'smart' 404 (etc) pages
-            * Changes in several places to raise RecordNotFound to trigger 404 'neatly'
-            * Added rspec support for optionally raising production-style errors in test env
-        * Some support for manually overriding open/active status of admin menu items
-        * lib/gemfile_plugins_helper.rb - new home for plugin-supporting methods from Gemfile
-        * rubycritic - now uncommented in the Gemfile, reek fixed their ruby 3.0 issues
-        * zxcvbn-ruby - intelligent password complexity checker
-            * PasswordsController - JSON endpoint for getting password scores and advice
-        * activerecord-analyze - adds .analyze method to AR objects, for investigating issues
+* Added:
+    * ShinyUserAuthentication and ShinyUserAuthorization concerns
+        * Splitting out auth code from User model
+    * ShinyUserContent concern - splitting off relations to user-owned content
+    * Links on user profiles, with a JS UI that very nearly works properly
+    * ErrorController - more standard way to provide 'smart' 404 (etc) pages
+        * Changes in several places to raise RecordNotFound to trigger 404 'neatly'
+        * Added rspec support for optionally raising production-style errors in test env
+    * Some support for manually overriding open/active status of admin menu items
+    * lib/gemfile_plugins_helper.rb - new home for plugin-supporting methods from Gemfile
+    * rubycritic - now uncommented in the Gemfile, reek fixed their ruby 3.0 issues
+    * zxcvbn-ruby - intelligent password complexity checker
+        * PasswordsController - JSON endpoint for getting password scores and advice
+    * activerecord-analyze - adds .analyze method to AR objects, for investigating issues
 
-    * Updated:
-        * Rails, from 6.1.0 to 6.1.1
-        * Puma, from 5.1 to 5.2
-        * Blazer, from 2.3.1 to 2.4.0
-            * Fixed the issue with recent versions by overriding the clear_helpers method
-        * MJMLSyntaxValidator rewritten - uses mjml directly rather than Mjml::Parser gem
-        * Admin area 'quick search' methods moved from controllers to models
-        * Minor code-quality tweaks in various admin controllers and some models
-            * In controllers, mostly setting instance variables in before_actions
-            * In models, several accessors changed from read/write to read-only
-        * Split user session and user registration tests into two separate files
+* Updated:
+    * Rails, from 6.1.0 to 6.1.1
+    * Puma, from 5.1 to 5.2
+    * Blazer, from 2.3.1 to 2.4.0
+        * Fixed the issue with recent versions by overriding the clear_helpers method
+    * MJMLSyntaxValidator rewritten - uses mjml directly rather than Mjml::Parser gem
+    * Admin area 'quick search' methods moved from controllers to models
+    * Minor code-quality tweaks in various admin controllers and some models
+        * In controllers, mostly setting instance variables in before_actions
+        * In models, several accessors changed from read/write to read-only
+    * Split user session and user registration tests into two separate files
 
-    * Removed:
-        * groupdate gem - this is related to Blazer, but wasn't being used
-        * Various post-login redirect code, particularly for admins
-            * It was architecturally horrible, and didn't offer enough value to justify that
-        * user_profile factory - profiles are auto-created along with users now
-            * There were quite a lot of very minor spec updates to adapt to this
-        * Static 404 and 500 pages
+* Removed:
+    * groupdate gem - this is related to Blazer, but wasn't being used
+    * Various post-login redirect code, particularly for admins
+        * It was architecturally horrible, and didn't offer enough value to justify that
+    * user_profile factory - profiles are auto-created along with users now
+        * There were quite a lot of very minor spec updates to adapt to this
+    * Static 404 and 500 pages
 
 
 ### 2021-01-01  21.01  January 2021: 'Wishing you a Happy New Year, a Happy New Rails, and a Happy New Ruby!'
 
-    * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.01
+* GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v21.01
 
-    * Headlines:
-        * Rails 6.1 !
-        * Ruby 3.0 !!
+* Headlines:
+    * Rails 6.1 !
+    * Ruby 3.0 !!
 
-    * Also notable:
-        * Pagination now uses Pagy rather than Kaminari
-        * Travis CI removed, as they no longer support open source projects :(
+* Also notable:
+    * Pagination now uses Pagy rather than Kaminari
+    * Travis CI removed, as they no longer support open source projects :(
 
-    * Possibly contentious Rubocop config change of the month ;)
-        * Layout/HashAlignment -> EnforcedStyle: table
+* Possibly contentious Rubocop config change of the month ;)
+    * Layout/HashAlignment -> EnforcedStyle: table
 
-    * Plugin versions all increased to 21.01
+* Plugin versions all increased to 21.01
 
-    * Added
-        * Pagy - new pagination gem, replacing Kaminari
-        * rubocop-rspec
-            * This triggered lots of minor changes to spec files, nothing major though
-            * Still two types of warning left to address (see .rubocop_todo.yml)
-        * rails_best_practices
-        * rubycritic
-            * Currently commented out in Gemfile due to Ruby 3.0 issues in its dependency chain, but config file included and all ready to go when reek catches up
-        * Typo CI config (https://github.com/marketplace/typo-ci)
-        * ActiveStorage added a new table, and a new column to an existing table
-        * Database indexes on capabilities.category_id, comments.parent_id, and shiny_pages_sections.default_page_id
+* Added
+    * Pagy - new pagination gem, replacing Kaminari
+    * rubocop-rspec
+        * This triggered lots of minor changes to spec files, nothing major though
+        * Still two types of warning left to address (see .rubocop_todo.yml)
+    * rails_best_practices
+    * rubycritic
+        * Currently commented out in Gemfile due to Ruby 3.0 issues in its dependency chain, but config file included and all ready to go when reek catches up
+    * Typo CI config (https://github.com/marketplace/typo-ci)
+    * ActiveStorage added a new table, and a new column to an existing table
+    * Database indexes on capabilities.category_id, comments.parent_id, and shiny_pages_sections.default_page_id
 
-    * Changed
-        * As headlined, two particularly significant version bumps this month:
-            * Rails, from 6.0 to 6.1
-            * Ruby, from 2.7 to 3.0
-                * This triggered downgrades in the codecov and fasterer gems
-                    * No noticeable impact from either of these
-                * Needs an unreleased fix for ActiveRecord-session-store
-                    * Hence, this gem is currently installing from GitHub HEAD
-        * Finished moving (almost) all theme files into the top-level /themes folder
-            * Theme JavaScript files still not ideally located, but better than it was
-                * Hooking up a theme with JavaScript requires creating a pack file at `/app/javascript/packs/{theme_name}.js`, which is clearly not how that boundary should work. The fix is probably themes-as-installable-gems. (Hold my beer?)
-        * Human-readable names for capability categories now come via i18n rather than various model methods
-        * ActiveRecord timestamp defaults overriden, to not include microseconds
-        * In test and dev environment config:
-            * Explicitly disabled precompiled asset check
-                * This got rid of hopefully spurious errors about theme and plugin assets
-            * Updated the name of an i18n-related setting
+* Changed
+    * As headlined, two particularly significant version bumps this month:
+        * Rails, from 6.0 to 6.1
+        * Ruby, from 2.7 to 3.0
+            * This triggered downgrades in the codecov and fasterer gems
+                * No noticeable impact from either of these
+            * Needs an unreleased fix for ActiveRecord-session-store
+                * Hence, this gem is currently installing from GitHub HEAD
+    * Finished moving (almost) all theme files into the top-level /themes folder
+        * Theme JavaScript files still not ideally located, but better than it was
+            * Hooking up a theme with JavaScript requires creating a pack file at `/app/javascript/packs/{theme_name}.js`, which is clearly not how that boundary should work. The fix is probably themes-as-installable-gems. (Hold my beer?)
+    * Human-readable names for capability categories now come via i18n rather than various model methods
+    * ActiveRecord timestamp defaults overriden, to not include microseconds
+    * In test and dev environment config:
+        * Explicitly disabled precompiled asset check
+            * This got rid of hopefully spurious errors about theme and plugin assets
+        * Updated the name of an i18n-related setting
 
-    * Frozen
-        * Blazer is currently locked to version 2.3.1, as 2.4.0 has a breaking change
-            * https://github.com/ankane/blazer/issues/315
-        * MJML is currently locked to version 4.7.1, as 4.8.0 has a breaking change
+* Frozen
+    * Blazer is currently locked to version 2.3.1, as 2.4.0 has a breaking change
+        * https://github.com/ankane/blazer/issues/315
+    * MJML is currently locked to version 4.7.1, as 4.8.0 has a breaking change
 
-    * Removed
-        * As mentioned above, Travis CI has been removed
-            * The company was sold and the new owners do not support open source :(
-                * See https://travis-ci.community/t/10567 for more background
-            * This means that there is currently no CI set up for older Ruby versions
-        * Kaminari (pagination gem, replaced by Pagy)
-        * The ShinyPaging concern (only existed to load Kaminari)
+* Removed
+    * As mentioned above, Travis CI has been removed
+        * The company was sold and the new owners do not support open source :(
+            * See https://travis-ci.community/t/10567 for more background
+        * This means that there is currently no CI set up for older Ruby versions
+    * Kaminari (pagination gem, replaced by Pagy)
+    * The ShinyPaging concern (only existed to load Kaminari)
 
 
 ### 2020-12-03  20.12  December 2020: The 'ShinyAccess and ActiveStorage' Edition
 
-    * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v20.12
+* GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v20.12
 
-    * Plugin versions:
-        * All plugin versions bumped to 20.12 - they've all had commits since 20.11 release
+* Plugin versions:
+    * All plugin versions bumped to 20.12 - they've all had commits since 20.11 release
 
-    * BREAKING CHANGES
-        * User profile data moved from users table into shiny_profiles_* tables
-            * Migration only handles table structure - DATA MIGRATION IS NOT HANDLED
-                * (When people are using the CMS in production, I'll write data migrations) :)
-        * Feature Flag name changes:
-            * recaptcha_for_registration -> recaptcha_for_registrations
-            * profile_pages -> user_profiles
-        * ShinyLists unsubscribe route changed from PUT to DELETE
-        * Assets and JavaScript files for themes have moved from app/ to vendor/
+* BREAKING CHANGES
+    * User profile data moved from users table into shiny_profiles_* tables
+        * Migration only handles table structure - DATA MIGRATION IS NOT HANDLED
+            * (When people are using the CMS in production, I'll write data migrations) :)
+    * Feature Flag name changes:
+        * recaptcha_for_registration -> recaptcha_for_registrations
+        * profile_pages -> user_profiles
+    * ShinyLists unsubscribe route changed from PUT to DELETE
+    * Assets and JavaScript files for themes have moved from app/ to vendor/
 
-    * Fixes since 20.11
-        * Fatal errors that could prevent the CMS from starting at all:
-            * ShinyPlugin checks whether plugins exist before attempting to load them
-            * ShinyPlugin de-duplicates SHINYCMS_PLUGINS before attempting to load them all
-        * Security issues:
-            * Admin area:
-                * Authorisation check when accessing /admin/stats (Blazer)
-            * Main site:
-                * Don't add new comments (or show reply links & forms) if discussion is locked
-        * Errors that only broke a specific page or feature-set:
-            * Get rid of double '.../search/search' in admin area search forms
-            * Displaying user profile pic from ActiveStorage works in local disk mode too
-        * Wasted database space:
-            * When dropping a comment flagged as 'blatant spam' by Akismet...
-                * Don't create CommentAuthor and EmailRecipient records!
-        * Lurkers (hadn't broken anything yet, but not the intended behaviour):
-            * 'Page with all element types' factory was adding each type twice
+* Fixes since 20.11
+    * Fatal errors that could prevent the CMS from starting at all:
+        * ShinyPlugin checks whether plugins exist before attempting to load them
+        * ShinyPlugin de-duplicates SHINYCMS_PLUGINS before attempting to load them all
+    * Security issues:
+        * Admin area:
+            * Authorisation check when accessing /admin/stats (Blazer)
+        * Main site:
+            * Don't add new comments (or show reply links & forms) if discussion is locked
+    * Errors that only broke a specific page or feature-set:
+        * Get rid of double '.../search/search' in admin area search forms
+        * Displaying user profile pic from ActiveStorage works in local disk mode too
+    * Wasted database space:
+        * When dropping a comment flagged as 'blatant spam' by Akismet...
+            * Don't create CommentAuthor and EmailRecipient records!
+    * Lurkers (hadn't broken anything yet, but not the intended behaviour):
+        * 'Page with all element types' factory was adding each type twice
 
-    * Added since 20.11
-        * Gems:
-            * Bugsnag gem
-                * Monitoring and bug triage service
-            * Cloudflare gem
-                * Puts real IP address in request.ip, instead of Cloudflare proxy address
-        * Plugins:
-            * ShinyAccess
-                * New plugin - adds basic ACL features for main site
-                    * Admin pages to add/remove Access Groups, and members of those groups
-                    * Main site helper to check access group membership, can be used to selectively show/hide content in any template
-            * ShinyProfiles:
-                * As part of separation from user accounts:
-                    * Main site page for users to edit their profile data
-                    * Admin area features for managing user profiles
-            * ShinyNewsletters:
-                * New rake task, to enqueue scheduled sends when they pass their send_at
-        * Main app:
-            * JSON endpoint to search usernames (used by ShinyAccess)
-        * Support libs (helpers, concerns, etc):
-            * ShinyTemplate / ShinyElement
-                * Use ActiveStorage for image elements
-            * Rake tasks:
-                * `shiny:sessions:clean` for removing short (probably bot) session data
-            * Utility scripts:
-                * New dotenv wrapper scripts for dev environment (to pick up .env.*):
-                    * `tools/shiny-bundle-install` wraps `bundle install`
-                        * Only matters if you don't want all of the plugins
-                    * `tools/shiny-sidekiq-dev` wraps `sidekiq`
-                        * Only matters if you want to override default value of any ENV var mentioned in config/sidekiq.yml
-        * Config:
-            * Explicit config for HTML sanitizer - used when displaying blog posts etc
-                * (full submitted HTML is stored, but output is heavily filtered)
-                * Added a number of 'basic necessity' tags and attributes to the allow-list that weren't allowed through by default (e.g. img tag, class attribute)
-            * More explicit config options to enable web stats and email open/click tracking
-        * Documentation:
-            * Moved content from docs/Developers/index.md to create docs/Contributing.md
-                * (GitHub looks for the latter and automatically shares it with PR creators)
-            * 'How to' guide for setting up a new site
-            * Basic information about some supported/tested cloud hosting services
-            * Stub doc for new ShinyAccess feature/plugin
-            * Separate doc for rake tasks for developers (just shiny:demo:dump currently)
-            * Notes on user personas (tl,dr: 'user' will probably (primarily) describe a different sub-group of CMS users to different types of developer)
+* Added since 20.11
+    * Gems:
+        * Bugsnag gem
+            * Monitoring and bug triage service
+        * Cloudflare gem
+            * Puts real IP address in request.ip, instead of Cloudflare proxy address
+    * Plugins:
+        * ShinyAccess
+            * New plugin - adds basic ACL features for main site
+                * Admin pages to add/remove Access Groups, and members of those groups
+                * Main site helper to check access group membership, can be used to selectively show/hide content in any template
+        * ShinyProfiles:
+            * As part of separation from user accounts:
+                * Main site page for users to edit their profile data
+                * Admin area features for managing user profiles
+        * ShinyNewsletters:
+            * New rake task, to enqueue scheduled sends when they pass their send_at
+    * Main app:
+        * JSON endpoint to search usernames (used by ShinyAccess)
+    * Support libs (helpers, concerns, etc):
+        * ShinyTemplate / ShinyElement
+            * Use ActiveStorage for image elements
+        * Rake tasks:
+            * `shiny:sessions:clean` for removing short (probably bot) session data
+        * Utility scripts:
+            * New dotenv wrapper scripts for dev environment (to pick up .env.*):
+                * `tools/shiny-bundle-install` wraps `bundle install`
+                    * Only matters if you don't want all of the plugins
+                * `tools/shiny-sidekiq-dev` wraps `sidekiq`
+                    * Only matters if you want to override default value of any ENV var mentioned in config/sidekiq.yml
+    * Config:
+        * Explicit config for HTML sanitizer - used when displaying blog posts etc
+            * (full submitted HTML is stored, but output is heavily filtered)
+            * Added a number of 'basic necessity' tags and attributes to the allow-list that weren't allowed through by default (e.g. img tag, class attribute)
+        * More explicit config options to enable web stats and email open/click tracking
+    * Documentation:
+        * Moved content from docs/Developers/index.md to create docs/Contributing.md
+            * (GitHub looks for the latter and automatically shares it with PR creators)
+        * 'How to' guide for setting up a new site
+        * Basic information about some supported/tested cloud hosting services
+        * Stub doc for new ShinyAccess feature/plugin
+        * Separate doc for rake tasks for developers (just shiny:demo:dump currently)
+        * Notes on user personas (tl,dr: 'user' will probably (primarily) describe a different sub-group of CMS users to different types of developer)
 
-    * Changed since 20.11
-        * Plugins:
-            * ShinyProfiles:
-                * Finish separating user profile data from user account data
-            * ShinyBlog:
-                * Change main site paging to use 'newer'/'older' links instead of full pager
-        * Support libs (helpers, concerns, etc):
-            * Move implementation of feature_flag_enabled? method from helper to model
-            * Admin menu sections default to closed instead of open
-            * Refactored plugin generator to make it more rubocop-compliant
-                * Extracted lots of little blocks of functionality into their own methods
-                * Moved a large chunk of the overall functionality into a new PluginBuilder file
-        * Data:
-            * Default data now includes a basic dashboard and charts for Blazer
-            * Demo site data now includes the ActiveStorage tables
-        * Tests:
-            * Mocked Akismet gem .open and .check methods
-                * No longer need a network connection for the tests to run
-                * Tests aren't using up credits on my Akismet test account
-        * Documentation:
-            * Plugins: added details of 'special' integration views and helpers
-            * Themes: updated paths for assets etc
-            * ShinyNewsletters: added details of rake task for scheduled sends
-            * Rake tasks: expand on purpose of each task
-            * Updates to TODO/in-progress/done docs
+* Changed since 20.11
+    * Plugins:
+        * ShinyProfiles:
+            * Finish separating user profile data from user account data
+        * ShinyBlog:
+            * Change main site paging to use 'newer'/'older' links instead of full pager
+    * Support libs (helpers, concerns, etc):
+        * Move implementation of feature_flag_enabled? method from helper to model
+        * Admin menu sections default to closed instead of open
+        * Refactored plugin generator to make it more rubocop-compliant
+            * Extracted lots of little blocks of functionality into their own methods
+            * Moved a large chunk of the overall functionality into a new PluginBuilder file
+    * Data:
+        * Default data now includes a basic dashboard and charts for Blazer
+        * Demo site data now includes the ActiveStorage tables
+    * Tests:
+        * Mocked Akismet gem .open and .check methods
+            * No longer need a network connection for the tests to run
+            * Tests aren't using up credits on my Akismet test account
+    * Documentation:
+        * Plugins: added details of 'special' integration views and helpers
+        * Themes: updated paths for assets etc
+        * ShinyNewsletters: added details of rake task for scheduled sends
+        * Rake tasks: expand on purpose of each task
+        * Updates to TODO/in-progress/done docs
 
-    * Removed since 20.11
-        * User profile details removed from user account model (User.pm) and related code
-            * (Now handled by ShinyProfiles plugin instead)
+* Removed since 20.11
+    * User profile details removed from user account model (User.pm) and related code
+        * (Now handled by ShinyProfiles plugin instead)
 
 
 ### 2020-11-09  20.11  November 2020: The 'tricky second album' release
 
-    * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v20.11
+* GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v20.11
 
-    * Plugin versions:
-        * All raised to 20.11 - there have been code changes in every single plugin since the 20.10 release
+* Plugin versions:
+    * All raised to 20.11 - there have been code changes in every single plugin since the 20.10 release
 
-    * Updates and changes since 20.10:
-        * General:
-            * Ruby version: 2.7.1 -> 2.7.2
-        * Rubocop:
-            * Added some enforcement of preferred whitespace rules
-            * Various updates to config for new versions with new cops
-        * Configuration:
-            * Added Setting.get_int method to get integer values from setting strings
-            * Added Setting.true? method to get boolean results from 'true'/'false' setting strings
-            * Started moving config that isn't secrets/credentials from ENV vars to Setting model
-        * Supporting code (Helpers, Concerns, etc):
-            * Added helper methods to abstract anywhere a main site view called a model
-            * Renamed Plugin model to ShinyPlugin
-            * Renamed FeatureFlagsHelper to ShinyFeatureFlagHelper
-            * Renamed PagingHelper to ShinyPagingHelper
-            * Renamed ElementsHelper to ShinyElementHelper
-            * Refactored AkismetHelper to allow checking generic form submissions as well as comments
-            * Pulled methods from ShinyMainSiteHelper into their own files:
-                * Added ShinyConsentHelper for retrieving ConsentVersion details
-                * Added ShinySettingsHelper for retrieving config settings
-        * Comments/Discussions:
-            * Changes to names of settings and code relating to who can post a comment (anon/etc)
-            * Moved comment author details into a separate model
-        * Mailer templates:
-            * Added fancier MJML templates for discussion, user, and email recipient mailers
+* Updates and changes since 20.10:
+    * General:
+        * Ruby version: 2.7.1 -> 2.7.2
+    * Rubocop:
+        * Added some enforcement of preferred whitespace rules
+        * Various updates to config for new versions with new cops
+    * Configuration:
+        * Added Setting.get_int method to get integer values from setting strings
+        * Added Setting.true? method to get boolean results from 'true'/'false' setting strings
+        * Started moving config that isn't secrets/credentials from ENV vars to Setting model
+    * Supporting code (Helpers, Concerns, etc):
+        * Added helper methods to abstract anywhere a main site view called a model
+        * Renamed Plugin model to ShinyPlugin
+        * Renamed FeatureFlagsHelper to ShinyFeatureFlagHelper
+        * Renamed PagingHelper to ShinyPagingHelper
+        * Renamed ElementsHelper to ShinyElementHelper
+        * Refactored AkismetHelper to allow checking generic form submissions as well as comments
+        * Pulled methods from ShinyMainSiteHelper into their own files:
+            * Added ShinyConsentHelper for retrieving ConsentVersion details
+            * Added ShinySettingsHelper for retrieving config settings
+    * Comments/Discussions:
+        * Changes to names of settings and code relating to who can post a comment (anon/etc)
+        * Moved comment author details into a separate model
+    * Mailer templates:
+        * Added fancier MJML templates for discussion, user, and email recipient mailers
 
-    * New since 20.10:
-        * General:
-            * Added .env.test file, replacing some setup code in spec/spec_helper.rb
-        * Gems:
-            * acts_as_paranoid (add soft delete to models)
-            * kaminari_route_prefix (fix kaminari pagination with Rails Engines routes)
-            * sidekiq-status (display additional details in sidekiq web dashboard)
-        * Supporting code (Helpers, Concerns, etc):
-            * Added ShinyPaging concern, to set up kaminari pagination on a model
-            * Added ShinySoftDelete concern, to set up acts_as_paranoid on a model
-            * Added ShinyClassName concern, for easy access to an i18n-translated name for a type of site content from its model (e.g. 'blog post')
-            * Added ShinyTemplateElement, to group common behaviour of template elements
-            * Added ShinyPostAtomFeed and ShinyPostAtomFeedEntry, for constructing atom feeds
-        * Admin Area:
-            * Added pagination to index/list pages for most plugins/features
-            * Added search to index/list pages for most plugins/features
-            * Added new page for viewing and managing non-user-account Email Recipients
-            * Added new 'Email' menu section, containing above page & mailer previews
-            * Added menu item for Sidekiq web dashboard
-        * Plugins:
-            * ShinyBlog & ShinyNews
-                * Added atom feed generation (can be written to local disk or AWS S3)
-                * Added pagination on main site
-            * ShinyForms
-                * Added reCAPTCHA and Akismet checking for form submissions
-            * ShinyNewsletters
-                * Added 'drag to sort' in admin area, for:
-                    * Elements on Newsletter Edition and Newsletter Template edit pages
-            * ShinyPages
-                * Added 'drag to sort' in admin area, for:
-                    * Elements on Page and Page Template edit pages
-                    * Pages and Sections on main Page/Section list page (/admin/pages)
+* New since 20.10:
+    * General:
+        * Added .env.test file, replacing some setup code in spec/spec_helper.rb
+    * Gems:
+        * acts_as_paranoid (add soft delete to models)
+        * kaminari_route_prefix (fix kaminari pagination with Rails Engines routes)
+        * sidekiq-status (display additional details in sidekiq web dashboard)
+    * Supporting code (Helpers, Concerns, etc):
+        * Added ShinyPaging concern, to set up kaminari pagination on a model
+        * Added ShinySoftDelete concern, to set up acts_as_paranoid on a model
+        * Added ShinyClassName concern, for easy access to an i18n-translated name for a type of site content from its model (e.g. 'blog post')
+        * Added ShinyTemplateElement, to group common behaviour of template elements
+        * Added ShinyPostAtomFeed and ShinyPostAtomFeedEntry, for constructing atom feeds
+    * Admin Area:
+        * Added pagination to index/list pages for most plugins/features
+        * Added search to index/list pages for most plugins/features
+        * Added new page for viewing and managing non-user-account Email Recipients
+        * Added new 'Email' menu section, containing above page & mailer previews
+        * Added menu item for Sidekiq web dashboard
+    * Plugins:
+        * ShinyBlog & ShinyNews
+            * Added atom feed generation (can be written to local disk or AWS S3)
+            * Added pagination on main site
+        * ShinyForms
+            * Added reCAPTCHA and Akismet checking for form submissions
+        * ShinyNewsletters
+            * Added 'drag to sort' in admin area, for:
+                * Elements on Newsletter Edition and Newsletter Template edit pages
+        * ShinyPages
+            * Added 'drag to sort' in admin area, for:
+                * Elements on Page and Page Template edit pages
+                * Pages and Sections on main Page/Section list page (/admin/pages)
 
-    * Fixes since 20.10:
-        * Fixed names of user mailer methods in various places (by adding '_instructions')
-        * Added missing edit-capability templates in a few plugins, that were causing admins to lose capabilities when edited and saved via the web UI
+* Fixes since 20.10:
+    * Fixed names of user mailer methods in various places (by adding '_instructions')
+    * Added missing edit-capability templates in a few plugins, that were causing admins to lose capabilities when edited and saved via the web UI
 
 
 ### 2020-10-01  20.10  October 2020: The 'First Birthday' release
 
-    * This is the first release, in celebration of 1 whole year working on this project!
+* This is the first release, in celebration of 1 whole year working on this project!
 
-    * GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v20.10
+* GitHub tag: https://github.com/denny/ShinyCMS-ruby/releases/tag/v20.10

--- a/plugins/ShinyAccess/lib/shiny_access/version.rb
+++ b/plugins/ShinyAccess/lib/shiny_access/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style'; year and month)
 module ShinyAccess
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyBlog/lib/shiny_blog/version.rb
+++ b/plugins/ShinyBlog/lib/shiny_blog/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style', YY.MM) - ShinyBlog plugin for ShinyCMS
 module ShinyBlog
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyCMS/lib/shinycms/version.rb
+++ b/plugins/ShinyCMS/lib/shinycms/version.rb
@@ -8,6 +8,6 @@
 
 # ShinyCMS version number ('Ubuntu style', YY.MM)
 module ShinyCMS
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyForms/lib/shiny_forms/version.rb
+++ b/plugins/ShinyForms/lib/shiny_forms/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style', YY.MM) - ShinyForms plugin for ShinyCMS
 module ShinyForms
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyInserts/lib/shiny_inserts/version.rb
+++ b/plugins/ShinyInserts/lib/shiny_inserts/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style', YY.MM) - ShinyInserts plugin for ShinyCMS
 module ShinyInserts
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyLists/lib/shiny_lists/version.rb
+++ b/plugins/ShinyLists/lib/shiny_lists/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style', YY.MM) - ShinyLists plugin for ShinyCMS
 module ShinyLists
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyNews/lib/shiny_news/version.rb
+++ b/plugins/ShinyNews/lib/shiny_news/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style', YY.MM) - ShinyNews plugin for ShinyCMS
 module ShinyNews
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyNewsletters/lib/shiny_newsletters/version.rb
+++ b/plugins/ShinyNewsletters/lib/shiny_newsletters/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style'; year and month)
 module ShinyNewsletters
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyPages/lib/shiny_pages/version.rb
+++ b/plugins/ShinyPages/lib/shiny_pages/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style', YY.MM) - ShinyPages plugin for ShinyCMS
 module ShinyPages
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinyProfiles/lib/shiny_profiles/version.rb
+++ b/plugins/ShinyProfiles/lib/shiny_profiles/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style', YY.MM) - ShinyProfiles plugin for ShinyCMS
 module ShinyProfiles
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinySEO/lib/shiny_seo/version.rb
+++ b/plugins/ShinySEO/lib/shiny_seo/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style'; year and month)
 module ShinySEO
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end

--- a/plugins/ShinySearch/lib/shiny_search/version.rb
+++ b/plugins/ShinySearch/lib/shiny_search/version.rb
@@ -8,6 +8,6 @@
 
 # Version number ('Ubuntu style', YY.MM) - ShinySearch plugin for ShinyCMS
 module ShinySearch
-  VERSION = '21.03'
+  VERSION = '21.04'
   public_constant :VERSION
 end


### PR DESCRIPTION
Main addition (and cause of some fairly major code shuffling) in this release is [Packwerk](https://github.com/Shopify/packwerk/blob/main/README.md) to enforce plugin boundaries.

Also added routes partials, bullet (N+1 query detection), CodeClimate coverage reporting, and the Items extension for Pagy (although the front-end widget for that refuses to work, yay JavaScript).

Plus lots of improvements to base controllers and mailers (now in the core plugin's app/public area), and moved Rails Email Preview engine, rubocop config, and ShinyCMS rake tasks, from main_app into the core plugin.