### PR TITLE
Bump gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ PATH
       mini_magick
       mjml-rails
       nokogiri (>= 1.10.4)
-      pagy
+      pagy (~> 4.3.0)
       persistent-dmnd
       pg (~> 1.2.3)
       pry-rails
@@ -162,7 +162,7 @@ PATH
     shiny_search (21.04)
       acts-as-taggable-on
       acts_as_paranoid
-      algoliasearch-rails
+      algoliasearch-rails (~> 1.25)
       ckeditor
       nokogiri (>= 1.11.0.rc4)
       pagy
@@ -269,12 +269,11 @@ GEM
     airbrake-ruby (5.2.0)
       rbtree3 (~> 0.5)
     akismet (3.0.0)
-    algolia (2.0.4)
-      faraday (>= 0.15, < 2.0)
-      multi_json (~> 1.0)
-      net-http-persistent
-    algoliasearch-rails (2.0.0)
-      algolia (< 3.0.0)
+    algoliasearch (1.27.5)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    algoliasearch-rails (1.25.0)
+      algoliasearch (>= 1.26.0, < 2.0.0)
       json (>= 1.5.1)
     amazing_print (1.3.0)
     ast (2.4.2)
@@ -422,6 +421,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.34)
@@ -471,8 +471,6 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    net-http-persistent (4.0.1)
-      connection_pool (~> 2.2)
     netaddr (2.0.4)
     nio4r (2.5.7)
     nokogiri (1.11.3)
@@ -490,7 +488,7 @@ GEM
       constant_resolver
       parser
       sorbet-runtime
-    pagy (4.5.1)
+    pagy (4.3.0)
     parallel (1.20.1)
     parallel_tests (3.7.0)
       parallel
@@ -510,7 +508,7 @@ GEM
       pry (>= 0.10.4)
     psych (3.3.1)
     public_suffix (4.0.6)
-    puma (5.2.2)
+    puma (5.3.0)
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,8 +173,6 @@ PATH
 
 GEM
   specs:
-    view_component (2.30.0)
-      activesupport (>= 5.0.0, < 7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -250,7 +248,7 @@ GEM
       activerecord (>= 5.0, < 6.2)
     acts_as_list (1.0.4)
       activerecord (>= 4.2)
-    acts_as_paranoid (0.7.2)
+    acts_as_paranoid (0.7.3)
       activerecord (>= 5.2, < 7.0)
       activesupport (>= 5.2, < 7.0)
     acts_as_votable (0.13.1)
@@ -271,16 +269,17 @@ GEM
     airbrake-ruby (5.2.0)
       rbtree3 (~> 0.5)
     akismet (3.0.0)
-    algoliasearch (1.27.5)
-      httpclient (~> 2.8, >= 2.8.3)
-      json (>= 1.5.1)
-    algoliasearch-rails (1.25.0)
-      algoliasearch (>= 1.26.0, < 2.0.0)
+    algolia (2.0.4)
+      faraday (>= 0.15, < 2.0)
+      multi_json (~> 1.0)
+      net-http-persistent
+    algoliasearch-rails (2.0.0)
+      algolia (< 3.0.0)
       json (>= 1.5.1)
     amazing_print (1.3.0)
     ast (2.4.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.449.0)
+    aws-partitions (1.452.0)
     aws-sdk-core (3.114.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -289,7 +288,7 @@ GEM
     aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.94.0)
+    aws-sdk-s3 (1.94.1)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -423,7 +422,6 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.34)
@@ -473,6 +471,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    net-http-persistent (4.0.1)
+      connection_pool (~> 2.2)
     netaddr (2.0.4)
     nio4r (2.5.7)
     nokogiri (1.11.3)
@@ -490,7 +490,7 @@ GEM
       constant_resolver
       parser
       sorbet-runtime
-    pagy (4.3.0)
+    pagy (4.5.1)
     parallel (1.20.1)
     parallel_tests (3.7.0)
       parallel
@@ -642,7 +642,7 @@ GEM
       pg
       terminal-table
     ruby-progressbar (1.11.0)
-    ruby-vips (2.1.0)
+    ruby-vips (2.1.2)
       ffi (~> 1.12)
     ruby2_keywords (0.0.4)
     ruby_parser (3.15.1)
@@ -672,14 +672,14 @@ GEM
       activerecord (>= 4)
       activesupport (>= 4)
     semantic_range (3.0.0)
-    sentry-rails (4.3.4)
+    sentry-rails (4.4.0)
       railties (>= 5.0)
-      sentry-ruby-core (~> 4.3.0)
-    sentry-ruby (4.3.2)
+      sentry-ruby-core (~> 4.4.0.pre.beta)
+    sentry-ruby (4.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
-      sentry-ruby-core (= 4.3.2)
-    sentry-ruby-core (4.3.2)
+      sentry-ruby-core (= 4.4.1)
+    sentry-ruby-core (4.4.1)
       concurrent-ruby
       faraday
     sexp_processor (4.15.2)
@@ -695,13 +695,13 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.2)
+    simplecov_json_formatter (0.1.3)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     sitemap_generator (6.1.2)
       builder (~> 3.0)
     smart_properties (1.15.0)
-    sorbet-runtime (0.5.6397)
+    sorbet-runtime (0.5.6403)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -725,6 +725,8 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     uniform_notifier (1.14.2)
+    view_component (2.31.1)
+      activesupport (>= 5.0.0, < 7.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)

--- a/plugins/ShinyAccess/db/seeds.rb
+++ b/plugins/ShinyAccess/db/seeds.rb
@@ -18,4 +18,4 @@ seeder.seed_feature_flag( name: :access, description: 'Access control features o
 seeder.seed_standard_admin_capabilities( category: :access_groups )
 
 category = seeder.seed_standard_admin_capabilities( category: :access_group_memberships )
-category.capabilities.destroy!( name: 'edit' )
+category.capabilities.destroy_fully!( name: 'edit' )

--- a/plugins/ShinyCMS/shinycms.gemspec
+++ b/plugins/ShinyCMS/shinycms.gemspec
@@ -83,7 +83,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ckeditor'
 
   # Pagination
-  spec.add_dependency 'pagy'
+  spec.add_dependency 'pagy', '~> 4.3.0'
 
   # Atom feeds
   spec.add_dependency 'rss'

--- a/plugins/ShinyLists/db/seeds.rb
+++ b/plugins/ShinyLists/db/seeds.rb
@@ -18,7 +18,7 @@ seeder.seed_feature_flag( name: :mailing_lists, description: 'Enable mailing lis
 seeder.seed_standard_admin_capabilities( category: :mailing_lists )
 
 category = seeder.seed_standard_admin_capabilities( category: :mailing_list_subscriptions )
-category.capabilities.destroy!( name: 'edit' )
+category.capabilities.destroy_fully!( name: 'edit' )
 
 # Consent version used when a list admin manually subscribes somebody
 seeder.seed_consent_version(

--- a/plugins/ShinySearch/shiny_search.gemspec
+++ b/plugins/ShinySearch/shiny_search.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pg', '~> 1.2.3'
 
   # Search back-ends
-  spec.add_dependency 'algoliasearch-rails'
+  spec.add_dependency 'algoliasearch-rails', '~> 1.25'
   spec.add_dependency 'pg_search'
 
   # Authorisation


### PR DESCRIPTION
* Held back `algoliasearch-rails`, which wanted to go from 1.2.5 to 2.x. This pulled in major changes to the other Algolia gems, and broke the mocking setup.
    * This is not urgent to fix, as the Algolia support is incomplete anyway.
* Held back `pagy`, which was only a minor update (4.3 to 4.5) but still broke quite dramatically. Looks like the template substitution syntax has changed or something along those lines.
    * This one is more important to resolve fairly swiftly, given the widespread use in the admin area (admin list/index pages for almost all plugins) and some use on main site too (blog and news plugins).