### PR TITLE
Mutation testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,14 @@ source 'https://rubygems.org' do
     # RSpec for Rails
     gem 'rspec-rails'
 
+    # Mutation testing
+    gem 'mutant-rspec', require: false
+
+    source 'https://oss:TavsFP4Rxs7vhBGX0Li5ksWM53EcWLyd@gem.mutant.dev' do
+      # Verify that we're an open source project
+      gem 'mutant-license'
+    end
+
     # Run tests in parallel
     gem 'parallel_tests'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,11 @@ GEM
       activesupport (>= 5.0.0, < 7.0)
 
 GEM
+  remote: https://oss:TavsFP4Rxs7vhBGX0Li5ksWM53EcWLyd@gem.mutant.dev/
+  specs:
+    mutant-license (0.1.1.2.1258176039107932962731638484160838054569.0)
+
+GEM
   remote: https://rubygems.org/
   specs:
     actioncable (6.1.3.2)
@@ -473,6 +478,14 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mutant (0.10.30)
+      diff-lcs (~> 1.3)
+      parser (~> 3.0.0)
+      regexp_parser (~> 2.0, >= 2.0.3)
+      unparser (~> 0.6.0)
+    mutant-rspec (0.10.30)
+      mutant (= 0.10.30)
+      rspec-core (>= 3.8.0, < 4.0.0)
     netaddr (2.0.4)
     nio4r (2.5.7)
     nokogiri (1.11.3)
@@ -725,6 +738,9 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     uniform_notifier (1.14.2)
+    unparser (0.6.0)
+      diff-lcs (~> 1.3)
+      parser (>= 3.0.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -771,6 +787,8 @@ DEPENDENCIES
   i18n-tasks (~> 0.9.33)!
   letter_opener_web (~> 1.0)!
   listen (~> 3.5)!
+  mutant-license!
+  mutant-rspec!
   overcommit!
   packwerk!
   parallel_tests!

--- a/tools/mutate
+++ b/tools/mutate
@@ -4,6 +4,9 @@
 #
 # ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
 
-# Run mutation tests on the specified plugin: `tools/mutate ShinySearch`
+# Run mutation tests on a specific class: tools/mutate ShinyProfiles::Link
+# Run mutation tests on a whole plugin:   tools/mutate ShinySEO*
 
-RAILS_ENV=test bundle exec mutant run -r ./config/environment --use rspec $1*
+# Note: Mutation testing is not fast; testing a large plugin may take hours.
+
+RAILS_ENV=test bundle exec mutant run -r ./config/environment --use rspec $1

--- a/tools/mutate
+++ b/tools/mutate
@@ -1,0 +1,9 @@
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2021 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+# Run mutation tests on the specified plugin: `tools/mutate ShinySearch`
+
+RAILS_ENV=test bundle exec mutant run -r ./config/environment --use rspec $1*


### PR DESCRIPTION
Adding [mutant](https://github.com/mbj/mutant#readme) gem for mutation testing (with an open source licence kindly provided by the author, thank you @mbj!)

Currently there is just a script to run `mutant` over a specific class or plugin. I'm pretty sure there is a lot more that could be done with this now that it's included; the mutant readme suggests viewing it as a code review tool rather than a test coverage tool - with each mutation that passes tests either showing a missing test _or showing code that could be simplified_.