### PR TITLE
Add formatting to configuration docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -53,4 +53,4 @@ User registration and posting comments can be protected from bots using Google's
 
 ### Have I Been Pwned - password leak checking
 
-The user registration and login features use Devise::PwnedPassword to check user's passwords against https://haveibeenpwned.com/Passwords and warn the user if they find a match, but this doesn't require any setup on your part.
+The user registration and login features use [Devise::PwnedPassword](https://github.com/michaelbanfield/devise-pwned_password) to check user's passwords against https://haveibeenpwned.com/Passwords and warn the user if they find a match, but this doesn't require any setup on your part.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -7,13 +7,13 @@ Configuration is split between the following locations:
 ### ENV vars
 
 * Mostly used for secrets (database details, API keys etc)
-* See docs/env.sample for a full list of available ENV settings
 * Usually loaded from `.env*` files, or from Settings > Config Vars on Heroku
+* See `docs/env.sample` for a full list of available ENV settings
 
 ### Feature Flags
 
 * Turn CMS features on (or off) for all users, logged-in only, or admin only
-* Controlled in the CMS admin area - /admin/feature-flags
+* Controlled in the CMS admin area - `/admin/feature-flags`
 * Can also be turned on or off, and listed, from the command line:
 ```
 rails shiny:features:list
@@ -23,7 +23,7 @@ rails shiny:feature:off[user_logins]
 ### Site Settings
 
 * Configuration of CMS options and features
-* Controlled in the CMS admin area - /admin/site-settings
+* Controlled in the CMS admin area - `/admin/site-settings`
 
 
 ## Services
@@ -53,4 +53,4 @@ User registration and posting comments can be protected from bots using Google's
 
 ### Have I Been Pwned - password leak checking
 
-The user registration and login features use [Devise::PwnedPassword](https://github.com/michaelbanfield/devise-pwned_password) to check user's passwords against https://haveibeenpwned.com/Passwords and warn the user if they find a match, but this doesn't require any setup on your part.
+The user registration and login features use [`Devise::PwnedPassword`](https://github.com/michaelbanfield/devise-pwned_password) to check user's passwords against https://haveibeenpwned.com/Passwords and warn the user if they find a match, but this doesn't require any setup on your part.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -7,8 +7,8 @@ Configuration is split between the following locations:
 ### ENV vars
 
 * Mostly used for secrets (database details, API keys etc)
-* Usually loaded from .env* files, or from Settings > Config Vars on Heroku
 * See docs/env.sample for a full list of available ENV settings
+* Usually loaded from `.env*` files, or from Settings > Config Vars on Heroku
 
 ### Feature Flags
 
@@ -28,7 +28,7 @@ rails shiny:feature:off[user_logins]
 
 ## Services
 
-The external services listed below are optional. If you add config details for them (via a .env* file (see [env.sample](env.sample)), or via your Config Vars on Heroku) then the related CMS features will be enabled or enhanced, otherwise those features will be unavailable or will have more limited functionality.
+The external services listed below are optional. If you add config details for them (via a `.env*` file (see [env.sample](env.sample)), or via your Config Vars on Heroku) then the related CMS features will be enabled or enhanced, otherwise those features will be unavailable or will have more limited functionality.
 
 ### Akismet - spam flagging
 
@@ -42,7 +42,7 @@ User uploaded files can be stored on AWS S3 instead of locally. To enable this f
 
 ### Bugsnag - error monitoring
 
-If you add a BUGSNAG_API_KEY then ShinyCMS will start reporting to your Bugsnag account.
+If you add a `BUGSNAG_API_KEY` then ShinyCMS will start reporting to your Bugsnag account.
 
 ### reCAPTCHA - bot protection
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -38,7 +38,7 @@ Processing comments in the moderation queue will send training data back to Akis
 
 ### AWS S3 - file storage
 
-User uploaded files can be stored on AWS S3 instead of locally. To enable this feature you will need to have an an AWS account, create an S3 bucket, and add the relevant keys to the ENV/config.
+User uploaded files can be stored on AWS S3 instead of locally. To enable this feature you will need to have an AWS account, create an S3 bucket, and add the relevant keys to the ENV/config.
 
 ### Bugsnag - error monitoring
 


### PR DESCRIPTION
Gudday!

While reading through the configuration documentation, I noticed some text elements which clashed with the markdown formatting.  It seemed best to format these elements as code since they were code-like things in the text and formatting them as such removed the clashes with markdown.  I also spotted a duplicate word, which I removed in a separate commit.  I also thought it might be handy for the reader to have a link to `Devise::PwnedPassword`, hence I added a link to the project's GitHub repo.  If you'd like such changes to be submitted in a separate PR, please just let me know :-)

I've split the changes into separate commits so that you can cheery-pick them if you so wish.  This PR is submitted in the hope that it is helpful; if you'd like anything changed or fixed, please don't hesitate to let me know and I'll update as appropriate and resubmit.

Cheers,

Paul