### PR TITLE
Move admin area JS sprinkles into /public for now

### DIFF
--- a/plugins/ShinyCMS/app/views/shinycms/admin/layouts/admin_area.html.erb
+++ b/plugins/ShinyCMS/app/views/shinycms/admin/layouts/admin_area.html.erb
@@ -65,6 +65,6 @@
     <%#= javascript_pack_tag 'admin_area'  %>
 
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-    <%= javascript_include_tag 'shinycms/admin_area' %>
+    <script src='/js/shinycms/admin_area.js'></script>
   </body>
 </html>

--- a/public/js/shinycms/admin_area.js
+++ b/public/js/shinycms/admin_area.js
@@ -1,0 +1,33 @@
+$( function() {
+  $( '#sortable' ).sortable({
+    handle: '.handle',
+    update: function( _e, _ui ) {
+      $( '#sort_order' ).val( $( this ).sortable( 'serialize' ) );
+    }
+  });
+
+  $( '#live-sortable' ).sortable({
+    handle: '.handle',
+    update: function( _e, _ui ) {
+      Rails.ajax({
+        url:  $( this ).data( 'url' ),
+        type: 'PUT',
+        data: $( this ).sortable( 'serialize' ),
+      });
+    }
+  });
+
+  $( '#find_user_by_username' ).autocomplete({
+    source: '/admin/users/usernames',
+    minLength: 3
+  });
+});
+
+function toggleShowHandles( show_handles ) {
+  var handles = document.getElementsByClassName( 'handle' );
+  var count = handles.length;
+
+  for ( var i = 0; i < count; i++ ) {
+    handles[i].hidden = !show_handles;
+  }
+}


### PR DESCRIPTION
This is a temporary fix for issues caused (in production only) by moving some admin area JS code from <script> tags in a view template to a separate .js file.

(I swear I could have written at least two more feature plugins in the time I've wasted f*&#ing around with JavaScript config files in this project so far) 😞 