### PR TITLE
Update CircleCI postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ references:
       RAILS_ENV: test
       SHINYCMS_THEME: TEST
   db: &db
-    image: circleci/postgres:10-alpine-ram
+    image: cimg/postgres:17.4.0
     environment:
       POSTGRES_USER: shinyuser
       POSTGRES_PASSWORD: shinypass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ references:
       RAILS_ENV: test
       SHINYCMS_THEME: TEST
   db: &db
-    image: cimg/postgres:17.4.0
+    image: cimg/postgres:17.4
     environment:
       POSTGRES_USER: shinyuser
       POSTGRES_PASSWORD: shinypass


### PR DESCRIPTION
Switch to newer CircleCI images for postgres (cimg/... instead of circleci/...).

No ramdisk variant any more, but doesn't seem to make that much difference.