### PR TITLE
Upgrade Pagy (legacy edition)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ source 'https://rubygems.org' do
   gem 'chartkick', '~> 5.1.4'
 
   # Pagy
-  gem 'pagy', '~> 7.0.11'
+  gem 'pagy', '~> 8.0.2'
 
   group :development, :test do
     # RSpec for Rails

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ source 'https://rubygems.org' do
   gem 'chartkick', '~> 5.1.4'
 
   # Pagy
-  gem 'pagy', '~> 8.0.2'
+  gem 'pagy', '~> 8.1.2'
 
   group :development, :test do
     # RSpec for Rails

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ source 'https://rubygems.org' do
   gem 'chartkick', '~> 5.1.4'
 
   # Pagy
-  gem 'pagy', '~> 8.1.2'
+  gem 'pagy', '~> 8.6.3'
 
   group :development, :test do
     # RSpec for Rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       acts-as-taggable-on
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -18,7 +18,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -48,7 +48,7 @@ PATH
       mjml-rails
       nokogiri (>= 1.10.4)
       packwerk-extensions
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       persistent-dmnd
       pg (>= 1.2.3, < 1.6.0)
       pry-rails
@@ -73,7 +73,7 @@ PATH
     shiny_forms (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -85,7 +85,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -96,7 +96,7 @@ PATH
     shiny_lists (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -109,7 +109,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -121,7 +121,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -133,7 +133,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -144,7 +144,7 @@ PATH
     shiny_profiles (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -166,7 +166,7 @@ PATH
       algoliasearch-rails (~> 1.25)
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (>= 5.10, < 8.0)
+      pagy (~> 8.0.2)
       pg (>= 1.2.3, < 1.6.0)
       pg_search
       pundit
@@ -571,7 +571,7 @@ GEM
       railties (>= 6.0.0)
       sorbet-runtime
       zeitwerk
-    pagy (7.0.11)
+    pagy (8.0.2)
     parallel (1.26.3)
     parallel_tests (4.9.1)
       parallel
@@ -888,7 +888,7 @@ DEPENDENCIES
   mutant-rspec!
   overcommit!
   packwerk (~> 3.2)!
-  pagy (~> 7.0.11)!
+  pagy (~> 8.0.2)!
   parallel_tests!
   pg (~> 1.5.9)!
   puma (~> 6.6)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       acts-as-taggable-on
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -18,7 +18,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -48,7 +48,7 @@ PATH
       mjml-rails
       nokogiri (>= 1.10.4)
       packwerk-extensions
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       persistent-dmnd
       pg (>= 1.2.3, < 1.6.0)
       pry-rails
@@ -73,7 +73,7 @@ PATH
     shiny_forms (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -85,7 +85,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -96,7 +96,7 @@ PATH
     shiny_lists (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -109,7 +109,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -121,7 +121,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -133,7 +133,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -144,7 +144,7 @@ PATH
     shiny_profiles (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -166,7 +166,7 @@ PATH
       algoliasearch-rails (~> 1.25)
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.1.2)
+      pagy (~> 8.6.3)
       pg (>= 1.2.3, < 1.6.0)
       pg_search
       pundit
@@ -571,7 +571,7 @@ GEM
       railties (>= 6.0.0)
       sorbet-runtime
       zeitwerk
-    pagy (8.1.2)
+    pagy (8.6.3)
     parallel (1.26.3)
     parallel_tests (4.9.1)
       parallel
@@ -888,7 +888,7 @@ DEPENDENCIES
   mutant-rspec!
   overcommit!
   packwerk (~> 3.2)!
-  pagy (~> 8.1.2)!
+  pagy (~> 8.6.3)!
   parallel_tests!
   pg (~> 1.5.9)!
   puma (~> 6.6)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       acts-as-taggable-on
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -18,7 +18,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -48,7 +48,7 @@ PATH
       mjml-rails
       nokogiri (>= 1.10.4)
       packwerk-extensions
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       persistent-dmnd
       pg (>= 1.2.3, < 1.6.0)
       pry-rails
@@ -73,7 +73,7 @@ PATH
     shiny_forms (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -85,7 +85,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -96,7 +96,7 @@ PATH
     shiny_lists (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -109,7 +109,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -121,7 +121,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -133,7 +133,7 @@ PATH
       acts_as_paranoid
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -144,7 +144,7 @@ PATH
     shiny_profiles (21.06)
       acts_as_paranoid
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pundit
       rails (>= 7.1.5.1, < 7.2)
@@ -166,7 +166,7 @@ PATH
       algoliasearch-rails (~> 1.25)
       ckeditor
       nokogiri (>= 1.11.0.rc4)
-      pagy (~> 8.0.2)
+      pagy (~> 8.1.2)
       pg (>= 1.2.3, < 1.6.0)
       pg_search
       pundit
@@ -571,7 +571,7 @@ GEM
       railties (>= 6.0.0)
       sorbet-runtime
       zeitwerk
-    pagy (8.0.2)
+    pagy (8.1.2)
     parallel (1.26.3)
     parallel_tests (4.9.1)
       parallel
@@ -888,7 +888,7 @@ DEPENDENCIES
   mutant-rspec!
   overcommit!
   packwerk (~> 3.2)!
-  pagy (~> 8.0.2)!
+  pagy (~> 8.1.2)!
   parallel_tests!
   pg (~> 1.5.9)!
   puma (~> 6.6)!

--- a/plugins/ShinyAccess/shiny_access.gemspec
+++ b/plugins/ShinyAccess/shiny_access.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyAccess/shiny_access.gemspec
+++ b/plugins/ShinyAccess/shiny_access.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyAccess/shiny_access.gemspec
+++ b/plugins/ShinyAccess/shiny_access.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyBlog/shiny_blog.gemspec
+++ b/plugins/ShinyBlog/shiny_blog.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyBlog/shiny_blog.gemspec
+++ b/plugins/ShinyBlog/shiny_blog.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyBlog/shiny_blog.gemspec
+++ b/plugins/ShinyBlog/shiny_blog.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyCMS/app/views/shinycms/includes/_newer_older_pager.html.erb
+++ b/plugins/ShinyCMS/app/views/shinycms/includes/_newer_older_pager.html.erb
@@ -1,4 +1,4 @@
-<%== pagy_prev_html pagy, text: t( 'shinycms.pager.newer' ) %>
+<%== pagy_prev_a pagy, text: t( 'shinycms.pager.newer' ) %>
 <span class="float-right">
-<%== pagy_next_html pagy, text: t( 'shinycms.pager.older' ) %>
+<%== pagy_next_a pagy, text: t( 'shinycms.pager.older' ) %>
 </span>

--- a/plugins/ShinyCMS/config/initializers/pagy.rb
+++ b/plugins/ShinyCMS/config/initializers/pagy.rb
@@ -67,7 +67,7 @@ require 'pagy/extras/bootstrap'
 
 # Support extra: https://ddnexus.github.io/pagy/extras/support
 # Extra support for features like: incremental, infinite, auto-scroll pagination
-require 'pagy/extras/support'
+require 'pagy/extras/pagy'
 
 # Items extra: https://ddnexus.github.io/pagy/extras/items
 # Allow the client to request a custom number of items per page with an optional selector UI

--- a/plugins/ShinyCMS/shinycms.gemspec
+++ b/plugins/ShinyCMS/shinycms.gemspec
@@ -86,7 +86,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ckeditor'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # Atom feeds
   spec.add_dependency 'rss'

--- a/plugins/ShinyCMS/shinycms.gemspec
+++ b/plugins/ShinyCMS/shinycms.gemspec
@@ -86,7 +86,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ckeditor'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # Atom feeds
   spec.add_dependency 'rss'

--- a/plugins/ShinyCMS/shinycms.gemspec
+++ b/plugins/ShinyCMS/shinycms.gemspec
@@ -86,7 +86,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ckeditor'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # Atom feeds
   spec.add_dependency 'rss'

--- a/plugins/ShinyForms/shiny_forms.gemspec
+++ b/plugins/ShinyForms/shiny_forms.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyForms/shiny_forms.gemspec
+++ b/plugins/ShinyForms/shiny_forms.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyForms/shiny_forms.gemspec
+++ b/plugins/ShinyForms/shiny_forms.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyInserts/shiny_inserts.gemspec
+++ b/plugins/ShinyInserts/shiny_inserts.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyInserts/shiny_inserts.gemspec
+++ b/plugins/ShinyInserts/shiny_inserts.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyInserts/shiny_inserts.gemspec
+++ b/plugins/ShinyInserts/shiny_inserts.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyLists/shiny_lists.gemspec
+++ b/plugins/ShinyLists/shiny_lists.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyLists/shiny_lists.gemspec
+++ b/plugins/ShinyLists/shiny_lists.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyLists/shiny_lists.gemspec
+++ b/plugins/ShinyLists/shiny_lists.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyNews/shiny_news.gemspec
+++ b/plugins/ShinyNews/shiny_news.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyNews/shiny_news.gemspec
+++ b/plugins/ShinyNews/shiny_news.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyNews/shiny_news.gemspec
+++ b/plugins/ShinyNews/shiny_news.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyNewsletters/shiny_newsletters.gemspec
+++ b/plugins/ShinyNewsletters/shiny_newsletters.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyNewsletters/shiny_newsletters.gemspec
+++ b/plugins/ShinyNewsletters/shiny_newsletters.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyNewsletters/shiny_newsletters.gemspec
+++ b/plugins/ShinyNewsletters/shiny_newsletters.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyPages/shiny_pages.gemspec
+++ b/plugins/ShinyPages/shiny_pages.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyPages/shiny_pages.gemspec
+++ b/plugins/ShinyPages/shiny_pages.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyPages/shiny_pages.gemspec
+++ b/plugins/ShinyPages/shiny_pages.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinyProfiles/shiny_profiles.gemspec
+++ b/plugins/ShinyProfiles/shiny_profiles.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyProfiles/shiny_profiles.gemspec
+++ b/plugins/ShinyProfiles/shiny_profiles.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinyProfiles/shiny_profiles.gemspec
+++ b/plugins/ShinyProfiles/shiny_profiles.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts_as_paranoid'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # HTML & XML parser
   spec.add_dependency 'nokogiri', '>= 1.11.0.rc4'

--- a/plugins/ShinySearch/shiny_search.gemspec
+++ b/plugins/ShinySearch/shiny_search.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.0.2'
+  spec.add_dependency 'pagy', '~> 8.1.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinySearch/shiny_search.gemspec
+++ b/plugins/ShinySearch/shiny_search.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '>= 5.10', '< 8.0'
+  spec.add_dependency 'pagy', '~> 8.0.2'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'

--- a/plugins/ShinySearch/shiny_search.gemspec
+++ b/plugins/ShinySearch/shiny_search.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'acts-as-taggable-on'
 
   # Pagination
-  spec.add_dependency 'pagy', '~> 8.1.2'
+  spec.add_dependency 'pagy', '~> 8.6.3'
 
   # CKEditor: WYSIWYG editor for admin area
   spec.add_dependency 'ckeditor'


### PR DESCRIPTION
Pagy gem updated from 6.5.0 to 8.6.3 (via 7.0.11, 8.0.2 and 8.1.2), with whatever changes were required to its usage along the way.

8.6.3 is the last release in their 'legacy' docs; next step is 9.0(.9), and from there up to 9.3(.4) which is their current release.