### PR TITLE
Add very simple rack::attack filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,11 +60,6 @@ source 'https://rubygems.org' do
     # Mutation testing
     gem 'mutant-rspec', require: false
 
-    source 'https://oss:TavsFP4Rxs7vhBGX0Li5ksWM53EcWLyd@gem.mutant.dev' do
-      # Verify that we're an open source project
-      gem 'mutant-license'
-    end
-
     # Run tests in parallel
     gem 'parallel_tests'
 

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ source 'https://rubygems.org' do
   # Charts
   gem 'chartkick', '~> 5.1.4'
 
+  # Request filtering
+  gem 'rack-attack'
+
   group :development, :test do
     # RSpec for Rails
     gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,11 +175,6 @@ PATH
       rails (>= 7.2.2.1, < 8.0)
 
 GEM
-  remote: https://oss:TavsFP4Rxs7vhBGX0Li5ksWM53EcWLyd@gem.mutant.dev/
-  specs:
-    mutant-license (0.1.1.2.1258176039107932962731638484160838054569.0)
-
-GEM
   remote: https://rubygems.org/
   specs:
     actioncable (7.2.2.1)
@@ -882,7 +877,6 @@ DEPENDENCIES
   i18n-tasks (~> 1.0.14)!
   letter_opener_web (~> 3.0)!
   listen (~> 3.9)!
-  mutant-license!
   mutant-rspec!
   overcommit!
   packwerk (~> 3.2)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,6 +597,8 @@ GEM
     pwned (2.4.1)
     racc (1.8.1)
     rack (3.1.12)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -884,6 +886,7 @@ DEPENDENCIES
   pg (~> 1.5.9)!
   puma (~> 6.6)!
   rack!
+  rack-attack!
   rails (~> 7.2.2.1)!
   rails-pg-extras!
   rails_email_preview!

--- a/plugins/ShinyCMS/config/initializers/rack_attack.rb
+++ b/plugins/ShinyCMS/config/initializers/rack_attack.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2025 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+Rack::Attack.blocklisted_responder =
+  lambda do |_|
+    # Using 204 to prevent bots filling up logging with meaningless errors
+    # Rack::Attack returns 403 for blocklists by default
+    [ 204, {}, [ 'No Content' ] ]
+  end
+
+Rack::Attack.blocklist( 'block all access to common Wordpress admin URLs' ) do |request|
+  # Requests are blocked if the return value is truthy
+  request.path.start_with?( '/wp-admin', '/wp-login' )
+end

--- a/plugins/ShinyCMS/spec/requests/shinycms/errors_controller_spec.rb
+++ b/plugins/ShinyCMS/spec/requests/shinycms/errors_controller_spec.rb
@@ -11,12 +11,12 @@ require 'rails_helper'
 # Tests for ShinyCMS error handlers
 RSpec.describe ShinyCMS::ErrorsController, type: :request do
   describe 'GET /wp-login.php (or any URL ending in .php)', :production_error_responses do
-    it 'returns a 400 (Bad Request) error - headers only, to keep it light' do
+    it 'returns a 204 (No Content) page' do
       get '/wp-login.php'
 
-      expect( response ).to have_http_status :bad_request
+      expect( response ).to have_http_status :no_content
 
-      expect( response.body ).to be_blank
+      expect( response.body ).to eq 'No Content'
     end
   end
 

--- a/plugins/ShinyCMS/spec/requests/shinycms/errors_controller_spec.rb
+++ b/plugins/ShinyCMS/spec/requests/shinycms/errors_controller_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe ShinyCMS::ErrorsController, type: :request do
     end
   end
 
+  describe 'GET /not_wordpress.php', :production_error_responses do
+    it 'returns a 400 (Bad Request) error - headers only, to keep it light' do
+      get '/not_wordpress.php'
+
+      expect( response ).to have_http_status :bad_request
+    end
+  end
+
   describe 'GET /no-such-path', :production_error_responses do
     it 'returns our Not Found page, with a 404 status' do
       get '/no-such-path'

--- a/tools/mutate
+++ b/tools/mutate
@@ -9,4 +9,4 @@
 
 # Note: Mutation testing is not fast; testing a large plugin may take hours.
 
-RAILS_ENV=test bundle exec mutant run -r ./config/environment --use rspec $1
+RAILS_ENV=test bundle exec mutant run -r ./config/environment --usage opensource --use rspec $1


### PR DESCRIPTION
Just catching the two most common WordPress admin URLs here for now, but might be worth expanding on this at a later date.