### PR TITLE
Add wp-includes to the list of WordPress crap to ignore

### DIFF
--- a/plugins/ShinyCMS/config/initializers/rack_attack.rb
+++ b/plugins/ShinyCMS/config/initializers/rack_attack.rb
@@ -15,5 +15,5 @@ Rack::Attack.blocklisted_responder =
 
 Rack::Attack.blocklist( 'block common Wordpress and other PHP URLs' ) do |request|
   # Requests are blocked if the return value is truthy
-  request.path.start_with?( '/wp-admin', '/wp-login', '/wp-content', '/account/password/new' )
+  request.path.start_with?( '/wp-admin', '/wp-login', '/wp-content', '/wp-includes', '/account/password/new' )
 end


### PR DESCRIPTION
After blocking wp-admin, wp-login, and wp-content yesterday, another piece of WordPress crap floated to the top of my logging this morning...