### PR TITLE
Change logout link to logout button

### DIFF
--- a/themes/halcyonic/stylesheets/halcyonic/shinycms.scss
+++ b/themes/halcyonic/stylesheets/halcyonic/shinycms.scss
@@ -52,7 +52,6 @@ a {
 }
 
 a:hover {
-  cursor:               grabbing;
   text-decoration:      underline;
 }
 
@@ -105,6 +104,22 @@ a:hover {
   background-image: -ms-linear-gradient(top, $button-bg-active, $red);
   background-image: linear-gradient(top, $button-bg-active, $red);
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.75), inset 0 2px 0 0 rgba(255, 192, 192, 0.5), inset 0 0 0 2px rgba(255, 96, 96, 0.85), 3px 3px 3px 1px rgba(0, 0, 0, 0.15);
+}
+
+.link-button {
+  background: transparent;
+  border: 0;
+  color: currentColor;
+  cursor: pointer;
+  display: inline;
+  font: inherit;
+  padding: 0;
+
+  -webkit-appearance: none;
+
+  &:hover {
+    color: #0f4880 !important;
+  }
 }
 
 textarea {

--- a/themes/halcyonic/views/includes/_footer.html.erb
+++ b/themes/halcyonic/views/includes/_footer.html.erb
@@ -9,8 +9,8 @@
                   <ul class="link-list last-child">
                     <li><%= link_to t( 'shiny_profiles.view_profile' ), shiny_profiles.profile_path( current_user.username ) %></li>
                     <li><%= link_to t( 'shiny_profiles.edit_profile' ), shiny_profiles.edit_profile_path( current_user.username ) %></li>
-                    <li><%= link_to t( 'shinycms.user.edit_account' ), shinycms.edit_user_registration_path %></li>
-                    <li><%= link_to t( 'shinycms.user.log_out' ), shinycms.destroy_user_session_path, data: {}, method: :delete %></li>
+                    <li><%= link_to t( 'shinycms.user.edit_account'  ), shinycms.edit_user_registration_path %></li>
+                    <li><%= button_to t( 'shinycms.user.log_out'     ), shinycms.destroy_user_session_path, data: {}, method: :delete, class: 'link-button' %></li>
                   </ul>
                   <% elsif feature_enabled? :user_login %>
                   <h2>Log in</h2>


### PR DESCRIPTION
At some point in the Rails 6-7-8 upgrade journey the logout link stopped working. This PR gets it working again, by changing it from a link to a button (styled to still look like a link).