### PR TITLE
Bring back rails-ujs

### DIFF
--- a/plugins/ShinyCMS/app/components/shinycms/admin/head_component.html.erb
+++ b/plugins/ShinyCMS/app/components/shinycms/admin/head_component.html.erb
@@ -3,6 +3,8 @@
 
     <%= javascript_include_tag Ckeditor.cdn_url if @load_ckeditor_js %>
 
+    <%= javascript_include_tag 'https://cdn.jsdelivr.net/npm/@rails/ujs@7.1.501/app/assets/javascripts/rails-ujs.min.js' %>
+
     <%= stylesheet_link_tag 'https://unpkg.com/@coreui/coreui@3.0.0/dist/css/coreui.min.css' %>
     <%= stylesheet_link_tag 'https://unpkg.com/@coreui/icons@1.0.0/css/free.min.css' %>
 


### PR DESCRIPTION
Fix various minor functionality issues caused by the default removal of rails-ujs during Rails 7.0 upgrade. Mainly delete confirm dialogues not working throughout admin area.