### PR TITLE
Add initialiser for BugSnag

### DIFF
--- a/plugins/ShinyCMS/config/initializers/bugsnag.rb
+++ b/plugins/ShinyCMS/config/initializers/bugsnag.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# ShinyCMS ~ https://shinycms.org
+#
+# Copyright 2009-2025 Denny de la Haye ~ https://denny.me
+#
+# ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
+
+bugsnag_api_key = ENV.fetch( 'BUGSNAG_API_KEY', '' )
+
+return if bugsnag_api_key.blank?
+
+# :nocov:
+
+Bugsnag.configure do |config|
+  config.api_key = bugsnag_api_key
+  config.discard_classes << 'ActiveRecord::RecordNotFound'
+end

--- a/plugins/ShinyCMS/config/initializers/sentry.rb
+++ b/plugins/ShinyCMS/config/initializers/sentry.rb
@@ -6,10 +6,11 @@
 #
 # ShinyCMS is free software; you can redistribute it and/or modify it under the terms of the GPL (version 2 or later)
 
-# :nocov:
-
 sentry_dsn = ENV.fetch( 'SENTRY_DSN', '' )
+
 return if sentry_dsn.blank?
+
+# :nocov:
 
 Sentry.init do |config|
   config.dsn = sentry_dsn


### PR DESCRIPTION
Ignore all 404 errors on BugSnag, so anything else that goes wrong over there stands out from the incessant noise of blind bot attacks aimed at WordPress sites.