### PR TITLE
Fix dev reload errors

### DIFF
--- a/plugins/ShinyCMS/app/models/shinycms/plugins.rb
+++ b/plugins/ShinyCMS/app/models/shinycms/plugins.rb
@@ -102,7 +102,9 @@ module ShinyCMS
         # (that will fail during development app reloading, because classes are redefined)
         # rubocop:disable Style/ClassEqualityComparison
         if element.class.name == 'ShinyCMS::Plugin'
+          # :nocov:
           element.class.name
+          # :nocov:
         else
           element.to_s.to_sym
         end


### PR DESCRIPTION
Don't symbolise ShinyCMS::Plugins, it causes dev reload errors