### PR TITLE
Fix rubocop-rspec warnings for RSpec/InstanceVariable and RSpec/AnyInstance

### DIFF
--- a/plugins/ShinyCMS/.rubocop_todo.yml
+++ b/plugins/ShinyCMS/.rubocop_todo.yml
@@ -14,7 +14,7 @@
 RSpec/AnyInstance:
   Exclude:
     #- 'spec/requests/shinycms/admin/comments_controller_spec.rb'
-    - 'spec/requests/shinycms/comments_controller_spec.rb'
+    #- 'spec/requests/shinycms/comments_controller_spec.rb'
     - 'spec/requests/shinycms/users/registrations_controller_spec.rb'
     - '../ShinyForms/spec/requests/shiny_forms/forms_controller_spec.rb'
     - '../ShinyLists/spec/requests/shiny_lists/subscriptions_controller_spec.rb'

--- a/plugins/ShinyCMS/.rubocop_todo.yml
+++ b/plugins/ShinyCMS/.rubocop_todo.yml
@@ -13,7 +13,7 @@
 # Offense count: 22
 RSpec/AnyInstance:
   Exclude:
-    - 'spec/requests/shinycms/admin/comments_controller_spec.rb'
+    #- 'spec/requests/shinycms/admin/comments_controller_spec.rb'
     - 'spec/requests/shinycms/comments_controller_spec.rb'
     - 'spec/requests/shinycms/users/registrations_controller_spec.rb'
     - '../ShinyForms/spec/requests/shiny_forms/forms_controller_spec.rb'

--- a/plugins/ShinyCMS/.rubocop_todo.yml
+++ b/plugins/ShinyCMS/.rubocop_todo.yml
@@ -10,14 +10,14 @@
 #
 # This file should be regenerated whenever Rubocop is updated.
 
-# Offense count: 22
+# Offense count: 11
 RSpec/AnyInstance:
   Exclude:
     - 'spec/requests/shinycms/users/registrations_controller_spec.rb'
     - '../ShinyForms/spec/requests/shiny_forms/forms_controller_spec.rb'
     - '../ShinyLists/spec/requests/shiny_lists/subscriptions_controller_spec.rb'
 
-# Offense count: 140
+# Offense count: 132
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Exclude:

--- a/plugins/ShinyCMS/.rubocop_todo.yml
+++ b/plugins/ShinyCMS/.rubocop_todo.yml
@@ -13,8 +13,6 @@
 # Offense count: 22
 RSpec/AnyInstance:
   Exclude:
-    #- 'spec/requests/shinycms/admin/comments_controller_spec.rb'
-    #- 'spec/requests/shinycms/comments_controller_spec.rb'
     - 'spec/requests/shinycms/users/registrations_controller_spec.rb'
     - '../ShinyForms/spec/requests/shiny_forms/forms_controller_spec.rb'
     - '../ShinyLists/spec/requests/shiny_lists/subscriptions_controller_spec.rb'
@@ -23,7 +21,6 @@ RSpec/AnyInstance:
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Exclude:
-    # - 'spec/models/shinycms/discussion_spec.rb'
     - 'spec/requests/shinycms/admin/comments_controller_spec.rb'
     - 'spec/requests/shinycms/admin/discussions_controller_spec.rb'
     - 'spec/requests/shinycms/comments_controller_spec.rb'

--- a/plugins/ShinyCMS/.rubocop_todo.yml
+++ b/plugins/ShinyCMS/.rubocop_todo.yml
@@ -14,7 +14,6 @@
 RSpec/AnyInstance:
   Exclude:
     - 'spec/requests/shinycms/users/registrations_controller_spec.rb'
-    - '../ShinyForms/spec/requests/shiny_forms/forms_controller_spec.rb'
     - '../ShinyLists/spec/requests/shiny_lists/subscriptions_controller_spec.rb'
 
 # Offense count: 132

--- a/plugins/ShinyCMS/.rubocop_todo.yml
+++ b/plugins/ShinyCMS/.rubocop_todo.yml
@@ -10,7 +10,7 @@
 #
 # This file should be regenerated whenever Rubocop is updated.
 
-# Offense count: 11
+# Offense count: 8
 RSpec/AnyInstance:
   Exclude:
     - 'spec/requests/shinycms/users/registrations_controller_spec.rb'

--- a/plugins/ShinyCMS/.rubocop_todo.yml
+++ b/plugins/ShinyCMS/.rubocop_todo.yml
@@ -23,7 +23,7 @@ RSpec/AnyInstance:
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:
   Exclude:
-    - 'spec/models/shinycms/discussion_spec.rb'
+    # - 'spec/models/shinycms/discussion_spec.rb'
     - 'spec/requests/shinycms/admin/comments_controller_spec.rb'
     - 'spec/requests/shinycms/admin/discussions_controller_spec.rb'
     - 'spec/requests/shinycms/comments_controller_spec.rb'

--- a/plugins/ShinyCMS/spec/models/shinycms/discussion_spec.rb
+++ b/plugins/ShinyCMS/spec/models/shinycms/discussion_spec.rb
@@ -11,16 +11,16 @@ require 'rails_helper'
 # Tests for discussion model
 RSpec.describe ShinyCMS::Discussion, type: :model do
   describe '.recently_active' do
-    before do
-      @active_last_week = create :news_post
-      @active_this_week = create :news_post
-      @less_active_post = create :news_post
-      @an_inactive_post = create :news_post
+    let!( :active_last_week )  { create :news_post }
+    let!( :active_this_week )  { create :news_post }
+    let!( :less_active_post )  { create :news_post }
+    let!( :an_inactive_post )  { create :news_post }
 
-      create :discussion, resource: @active_last_week, comment_count: 5, comments_posted_at: 8.days.ago
-      create :discussion, resource: @active_this_week, comment_count: 4
-      create :discussion, resource: @less_active_post, comment_count: rand( 1..3 )
-      create :discussion, resource: @an_inactive_post, comment_count: 0
+    before do
+      create :discussion, resource: active_last_week, comment_count: 5, comments_posted_at: 8.days.ago
+      create :discussion, resource: active_this_week, comment_count: 4
+      create :discussion, resource: less_active_post, comment_count: rand( 1..3 )
+      create :discussion, resource: an_inactive_post, comment_count: 0
     end
 
     context 'without params' do
@@ -28,7 +28,7 @@ RSpec.describe ShinyCMS::Discussion, type: :model do
         active, counts = described_class.recently_active
 
         expect( active.length ).to eq 2
-        expect( active.find( counts.to_h.keys.first ).resource ).to eq @active_this_week
+        expect( active.find( counts.to_h.keys.first ).resource ).to eq active_this_week
       end
     end
 
@@ -37,7 +37,7 @@ RSpec.describe ShinyCMS::Discussion, type: :model do
         active, counts = described_class.recently_active( days: 14 )
 
         expect( active.length ).to eq 3
-        expect( active.find( counts.to_h.keys.first ).resource ).to eq @active_last_week
+        expect( active.find( counts.to_h.keys.first ).resource ).to eq active_last_week
       end
     end
 
@@ -47,8 +47,8 @@ RSpec.describe ShinyCMS::Discussion, type: :model do
 
         expect( active.length ).to eq 2
         # TODO: expect( active.resources ).not_to include @an_inactive_post
-        expect( active.first.resource  ).not_to eq @an_inactive_post
-        expect( active.second.resource ).not_to eq @an_inactive_post
+        expect( active.first.resource  ).not_to eq an_inactive_post
+        expect( active.second.resource ).not_to eq an_inactive_post
       end
     end
   end

--- a/plugins/ShinyCMS/spec/requests/shinycms/admin/comments_controller_spec.rb
+++ b/plugins/ShinyCMS/spec/requests/shinycms/admin/comments_controller_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe ShinyCMS::Admin::CommentsController, type: :request do
     end
 
     it 'deletes the selected comments if you say they are spam' do
-      allow_any_instance_of( Akismet::Client ).to receive( :open )
-      allow_any_instance_of( Akismet::Client ).to receive( :spam ).and_return( true )
+      akismet_client = instance_double( Akismet::Client, open: nil, spam: true )
+      allow( Akismet::Client ).to receive( :new ).and_return( akismet_client )
 
       @nested1.mark_as_spam
       @comment2.mark_as_spam
@@ -116,8 +116,8 @@ RSpec.describe ShinyCMS::Admin::CommentsController, type: :request do
     end
 
     it 'removes spam flags from the selected comments if you say they are not spam' do
-      allow_any_instance_of( Akismet::Client ).to receive( :open )
-      allow_any_instance_of( Akismet::Client ).to receive( :ham  ).and_return( true )
+      akismet_client = instance_double( Akismet::Client, open: nil, ham: true )
+      allow( Akismet::Client ).to receive( :new ).and_return( akismet_client )
 
       @nested1.mark_as_spam
       @comment2.mark_as_spam
@@ -146,8 +146,8 @@ RSpec.describe ShinyCMS::Admin::CommentsController, type: :request do
     end
 
     it 'reports an error if it fails to remove spam flags' do
-      allow_any_instance_of( Akismet::Client ).to receive( :open )
-      allow_any_instance_of( Akismet::Client ).to receive( :ham  ).and_return( true )
+      akismet_client = instance_double( Akismet::Client, open: nil, ham: true )
+      allow( Akismet::Client ).to receive( :new ).and_return( akismet_client )
       allow( ShinyCMS::Comment ).to receive( :mark_all_as_ham ).and_return( false )
 
       @nested1.mark_as_spam

--- a/plugins/ShinyCMS/spec/requests/shinycms/comments_controller_spec.rb
+++ b/plugins/ShinyCMS/spec/requests/shinycms/comments_controller_spec.rb
@@ -139,7 +139,6 @@ RSpec.describe ShinyCMS::CommentsController, type: :request do
     end
 
     it 'adds a new top-level comment to the discussion, with a recaptcha check' do
-      allow_any_instance_of( described_class ).to receive( :recaptcha_v3_site_key ).and_return( 'A_KEY' )
       allow( described_class ).to receive( :recaptcha_v3_secret_key ).and_return( 'A_KEY' )
 
       ShinyCMS::FeatureFlag.enable :recaptcha_for_comments
@@ -165,8 +164,8 @@ RSpec.describe ShinyCMS::CommentsController, type: :request do
 
     it 'classifies a new comment as spam after checking Akismet' do
       ShinyCMS::FeatureFlag.enable :akismet_for_comments
-      allow_any_instance_of( Akismet::Client ).to receive( :open  )
-      allow_any_instance_of( Akismet::Client ).to receive( :check ).and_return( [ true, false ] )
+      akismet_client = instance_double( Akismet::Client, open: nil, check: [ true, false ] )
+      allow( Akismet::Client ).to receive( :new ).and_return( akismet_client )
 
       always_fail_author_name = 'viagra-test-123'
       title = Faker::Books::CultureSeries.unique.culture_ship
@@ -193,8 +192,8 @@ RSpec.describe ShinyCMS::CommentsController, type: :request do
 
     it "doesn't save a new comment if Akismet classifies it as 'blatant' spam" do
       ShinyCMS::FeatureFlag.enable :akismet_for_comments
-      allow_any_instance_of( Akismet::Client ).to receive( :open  )
-      allow_any_instance_of( Akismet::Client ).to receive( :check ).and_return( [ true, true ] )
+      akismet_client = instance_double( Akismet::Client, open: nil, check: [ true, true ] )
+      allow( Akismet::Client ).to receive( :new ).and_return( akismet_client )
 
       name  = Faker::Name.unique.name
       email = Faker::Internet.unique.email

--- a/plugins/ShinyForms/spec/requests/shiny_forms/forms_controller_spec.rb
+++ b/plugins/ShinyForms/spec/requests/shiny_forms/forms_controller_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe ShinyForms::FormsController, type: :request do
   before do
     create :top_level_page
 
-    allow_any_instance_of( Akismet::Client ).to receive( :open  )
-    allow_any_instance_of( Akismet::Client ).to receive( :check ).and_return( [ false, false ] )
-    allow_any_instance_of( described_class ).to receive( :recaptcha_v3_site_key ).and_return( 'A_KEY' )
+    akismet_client = instance_double( Akismet::Client, open: nil, check: [ false, false ] )
+    allow( Akismet::Client ).to receive( :new ).and_return( akismet_client )
     allow( described_class ).to receive( :recaptcha_v3_secret_key ).and_return( 'A_KEY' )
   end
 


### PR DESCRIPTION
Fix #846 - (Fixed the two first files for AnyInstance (spec/requests/shinycms/admin/comments_controller_spec.rb and spec/requests/shinycms/comments_controller_spec.rb) and the first file for InstanceVariable (spec/models/shinycms/discussion_spec.rb)).